### PR TITLE
fix: cache release notes responses

### DIFF
--- a/apps/api/version-control.js
+++ b/apps/api/version-control.js
@@ -1,12 +1,18 @@
 const axios = require("axios");
+const fs = require("fs");
+const path = require("path");
 const packageJson = require("./package.json");
 const { compareVersions } = require("compare-versions");
 const memoizee = require("memoizee");
+const { getConfigDir } = require("./utils/storage-paths");
 
 const REPO_OWNER = process.env.JS_REPO_OWNER || "Nerdy-Technician";
 const REPO_NAME = process.env.JS_REPO_NAME || "JellyGlance";
 const RELEASES_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases`;
 const RELEASES_ATOM_URL = `${RELEASES_URL}.atom`;
+const RELEASE_CACHE_TTL_MS = Number(process.env.JS_RELEASE_CACHE_TTL_MS || 6 * 60 * 60 * 1000);
+const RELEASE_CACHE_MAX_STALE_MS = Number(process.env.JS_RELEASE_CACHE_MAX_STALE_MS || 14 * 24 * 60 * 60 * 1000);
+const RELEASE_CACHE_FILE = path.join(getConfigDir(), "release-notes-cache.json");
 
 function normalizeVersion(version) {
   return String(version || "").trim().replace(/^v/i, "");
@@ -69,29 +75,128 @@ function normalizeRelease(release) {
   };
 }
 
-async function fetchReleaseNotes() {
-  const currentVersion = packageJson.version;
-  const channel = releaseChannel(currentVersion);
-  const response = await axios.get(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases`, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      "User-Agent": `JellyGlance/${currentVersion}`,
-    },
-    params: {
-      per_page: 20,
-    },
-    timeout: 10000,
-  });
+function readReleaseCache() {
+  try {
+    if (!fs.existsSync(RELEASE_CACHE_FILE)) {
+      return null;
+    }
+
+    return JSON.parse(fs.readFileSync(RELEASE_CACHE_FILE, "utf8"));
+  } catch (error) {
+    console.warn(`Unable to read release notes cache: ${error.message}`);
+    return null;
+  }
+}
+
+function writeReleaseCache(data) {
+  try {
+    fs.mkdirSync(path.dirname(RELEASE_CACHE_FILE), { recursive: true });
+    fs.writeFileSync(
+      RELEASE_CACHE_FILE,
+      JSON.stringify(
+        {
+          cached_at: new Date().toISOString(),
+          data,
+        },
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    console.warn(`Unable to write release notes cache: ${error.message}`);
+  }
+}
+
+function getCachedReleaseNotes({ allowStale = false } = {}) {
+  const cache = readReleaseCache();
+  if (!cache?.cached_at || !cache?.data?.releases?.length) {
+    return null;
+  }
+
+  const age = Date.now() - new Date(cache.cached_at).getTime();
+  const maxAge = allowStale ? RELEASE_CACHE_MAX_STALE_MS : RELEASE_CACHE_TTL_MS;
+  if (!Number.isFinite(age) || age < 0 || age > maxAge) {
+    return null;
+  }
+
+  return {
+    ...cache.data,
+    cached: true,
+    cached_at: cache.cached_at,
+    stale: age > RELEASE_CACHE_TTL_MS,
+  };
+}
+
+function getFallbackReleaseNotes(currentVersion, channel) {
+  const version = normalizeVersion(currentVersion);
 
   return {
     current_version: currentVersion,
     channel,
     releases_url: RELEASES_URL,
-    releases: (response.data || [])
-      .filter((release) => !release.draft)
-      .filter((release) => (channel === "beta" ? release.prerelease : !release.prerelease))
-      .map(normalizeRelease),
+    cached: false,
+    fallback: true,
+    releases: [
+      {
+        id: `fallback-${version}`,
+        version,
+        name: `JellyGlance v${version}`,
+        date: null,
+        prerelease: channel === "beta",
+        draft: false,
+        url: `${RELEASES_URL}/tag/v${version}`,
+        body: `Release notes are temporarily unavailable because GitHub could not be reached. View JellyGlance v${version} on GitHub for the full notes.`,
+      },
+    ],
   };
+}
+
+async function fetchReleaseNotes() {
+  const currentVersion = packageJson.version;
+  const channel = releaseChannel(currentVersion);
+  const cached = getCachedReleaseNotes();
+  if (cached?.current_version === currentVersion && cached?.channel === channel) {
+    return cached;
+  }
+
+  try {
+    const response = await axios.get(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": `JellyGlance/${currentVersion}`,
+        ...(process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
+      },
+      params: {
+        per_page: 20,
+      },
+      timeout: 10000,
+    });
+
+    const data = {
+      current_version: currentVersion,
+      channel,
+      releases_url: RELEASES_URL,
+      releases: (response.data || [])
+        .filter((release) => !release.draft)
+        .filter((release) => (channel === "beta" ? release.prerelease : !release.prerelease))
+        .map(normalizeRelease),
+    };
+
+    if (data.releases.length) {
+      writeReleaseCache(data);
+    }
+
+    return data;
+  } catch (error) {
+    const staleCache = getCachedReleaseNotes({ allowStale: true });
+    if (staleCache?.current_version === currentVersion && staleCache?.channel === channel) {
+      console.warn(`Using cached release notes after GitHub fetch failed: ${error.message}`);
+      return staleCache;
+    }
+
+    console.warn(`Using fallback release notes after GitHub fetch failed: ${error.message}`);
+    return getFallbackReleaseNotes(currentVersion, channel);
+  }
 }
 
 async function checkForUpdates() {


### PR DESCRIPTION
## Summary
- Cache GitHub release note responses on the config volume
- Use stale cache when GitHub is unavailable or rate-limited
- Support GITHUB_TOKEN for higher API limits
- Return a current-version fallback when no cache exists

## Test
- node --check apps/api/version-control.js