### PR TITLE
fix: preserve GHCR multi-arch manifests

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -189,24 +189,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Delete untagged GHCR package versions
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKAGE_OWNER: ${{ github.repository_owner }}
-          PACKAGE_NAME: jellyglance
-        run: |
-          versions="$(gh api --paginate "/users/${PACKAGE_OWNER}/packages/container/${PACKAGE_NAME}/versions" --jq '.[] | select((.metadata.container.tags | length) == 0) | .id')"
-
-          if [ -z "${versions}" ]; then
-            echo "No untagged GHCR package versions found."
-            exit 0
-          fi
-
-          printf '%s\n' "${versions}" | while IFS= read -r version_id; do
-            echo "Deleting untagged GHCR package version ${version_id}"
-            gh api --method DELETE "/users/${PACKAGE_OWNER}/packages/container/${PACKAGE_NAME}/versions/${version_id}"
-          done
-
       - name: Create and push git tag
         run: |
           git tag -a "${{ steps.release.outputs.tag }}" -m "${{ steps.release.outputs.title }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,21 +41,3 @@ jobs:
           sbom: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Delete untagged GHCR package versions
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKAGE_OWNER: ${{ github.repository_owner }}
-          PACKAGE_NAME: jellyglance
-        run: |
-          versions="$(gh api --paginate "/users/${PACKAGE_OWNER}/packages/container/${PACKAGE_NAME}/versions" --jq '.[] | select((.metadata.container.tags | length) == 0) | .id')"
-
-          if [ -z "${versions}" ]; then
-            echo "No untagged GHCR package versions found."
-            exit 0
-          fi
-
-          printf '%s\n' "${versions}" | while IFS= read -r version_id; do
-            echo "Deleting untagged GHCR package version ${version_id}"
-            gh api --method DELETE "/users/${PACKAGE_OWNER}/packages/container/${PACKAGE_NAME}/versions/${version_id}"
-          done


### PR DESCRIPTION
## Summary
- remove the GHCR untagged-version cleanup after Docker pushes
- preserve the untagged child manifests required by multi-platform image indexes

## Validation
- YAML parse check for Docker and release workflows