### PR TITLE
fix: add library refresh supporting indexes

### DIFF
--- a/apps/api/migrations/100_add_refresh_supporting_indexes.js
+++ b/apps/api/migrations/100_add_refresh_supporting_indexes.js
@@ -1,0 +1,21 @@
+exports.up = async function (knex) {
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_jg_seasons_series_id
+    ON public.jf_library_seasons ("SeriesId");
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_jg_episodes_season_id
+    ON public.jf_library_episodes ("SeasonId");
+  `);
+
+  await knex.raw(`
+    ANALYZE public.jf_library_seasons;
+    ANALYZE public.jf_library_episodes;
+  `);
+};
+
+exports.down = async function (knex) {
+  await knex.raw(`DROP INDEX IF EXISTS public.idx_jg_episodes_season_id;`);
+  await knex.raw(`DROP INDEX IF EXISTS public.idx_jg_seasons_series_id;`);
+};


### PR DESCRIPTION
## Summary

- add indexes for the season-to-series and episode-to-season lookups used by the library play-count/play-time view
- refresh planner statistics after creating the indexes
- provide a reversible migration

## Root cause

The materialized view js_library_items_with_playcount_playtime selects from jf_library_items_with_playcount_playtime. On larger libraries, correlated lookups against jf_library_seasons.SeriesId and jf_library_episodes.SeasonId were performing repeated sequential scans.

In one production library this caused a refresh to run for more than five hours, allowed refresh requests to queue, and exhausted PostgreSQL client connections. The estimated plan cost fell from about 1.26 billion to 7.42 million after adding these indexes, and a fresh full refresh now completes in about one second.

## Production validation on v1.2.2

Both production installations now run the official JellyGlance v1.2.2 image (revision 6c8dbd2). This release still does not create either proposed index, so stock installations with large libraries remain exposed to the same repeated-scan behavior.

After upgrading to v1.2.2 with the proposed indexes retained:

- both installations are healthy with zero container restarts
- full materialized-view refreshes complete in 955 ms and 1.63 seconds
- both indexes remain valid, with no queued refreshes, migration locks, or long-running database queries

Based on this validation against the latest stable release, adding the indexes through a JellyGlance migration is still recommended so existing and new installations receive the performance protection automatically.

## Verification

- PostgreSQL 16 integration: migration up twice, then down
- migration syntax and focused structural assertions
- npm run i18n:check
- npm run lint
- npm run build
- npm run build:docs
- validated on two existing installations with valid indexes and approximately one-second full materialized-view refreshes
