### PR TITLE
chore: prepare v1.2.3 beta redesign

### DIFF
--- a/.github/RELEASE.BETA
+++ b/.github/RELEASE.BETA
@@ -5,6 +5,9 @@ title: JellyGlance v1.2.3 Beta 1
 
 Welcome to the big UI beta.
 
+This one is all about turning JellyGlance into a cleaner, calmer, more useful control centre. The pages have had a proper redesign pass, Settings has been reorganised, Tdarr gets a real home, Kiosk mode is customisable, and a lot of the small visual snags have been polished away.
+
+It is still a beta, but it is a very busy little beta.
 
 ## The Big Glow-Up
 
@@ -12,6 +15,8 @@ Welcome to the big UI beta.
 
 - Refreshed the main UI across Home, Settings, Statistics, Requests, Activity, Users, Wizarr, About, and integrations.
 - Tightened page spacing, card sizing, modal sizing, and sidebar behaviour.
+- Reduced oversized areas after the v1.2.2 reset while keeping the current JellyGlance colour style.
+- Improved overflow handling so Settings tabs and dense pages stop wandering off-screen.
 - Cleaned up hover states, active pills, category labels, and sidebar twitching.
 
 ### A Smarter Home
@@ -79,7 +84,7 @@ Welcome to the big UI beta.
 ### Theme And Appearance
 
 - Improved theme preset previews.
-- Theme changes now preview first
+- Theme changes now preview first and only apply after pressing Update.
 - Added a Custom theme option.
 - Improved custom colour handling.
 - Cleaned up profile modal sizing, alignment, text readability, and footer buttons.
@@ -142,6 +147,16 @@ Welcome to the big UI beta.
 - Removed bot wording from contributor display.
 - Reworked the contributor area so it sits in a more useful place.
 
+## Fixes And Tiny Sharp Edges Removed
+
+- Fixed the profile/account hover pill so it fills the row properly.
+- Removed broad global nav hover styling that leaked into Settings.
+- Fixed category highlighting in Settings.
+- Fixed Settings sidebar twitching by replacing the generated sidebar tab nav with stable grouped markup.
+- Improved backup page sizing.
+- Improved authorised devices and plugin cards.
+- Improved active transcode page loading behaviour.
+- Fixed multiple cases where text, pills, cards, or controls could clip, drift, or feel cramped.
 
 ## Beta Notes
 

--- a/apps/api/migrations/100_add_refresh_supporting_indexes.js
+++ b/apps/api/migrations/100_add_refresh_supporting_indexes.js
@@ -1,0 +1,21 @@
+exports.up = async function (knex) {
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_jg_seasons_series_id
+    ON public.jf_library_seasons ("SeriesId");
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_jg_episodes_season_id
+    ON public.jf_library_episodes ("SeasonId");
+  `);
+
+  await knex.raw(`
+    ANALYZE public.jf_library_seasons;
+    ANALYZE public.jf_library_episodes;
+  `);
+};
+
+exports.down = async function (knex) {
+  await knex.raw(`DROP INDEX IF EXISTS public.idx_jg_episodes_season_id;`);
+  await knex.raw(`DROP INDEX IF EXISTS public.idx_jg_seasons_series_id;`);
+};

--- a/apps/api/routes/api.js
+++ b/apps/api/routes/api.js
@@ -10,7 +10,7 @@ const pgp = require("pg-promise")();
 const { randomUUID } = require("crypto");
 
 const configClass = require("../classes/config");
-const { checkForUpdates, fetchReleaseNotes } = require("../version-control");
+const { checkForUpdates, fetchGithubContributors, fetchReleaseNotes } = require("../version-control");
 const API = require("../classes/api-loader");
 const { sendUpdate } = require("../ws");
 const { tables } = require("../global/backup_tables");
@@ -37,8 +37,10 @@ const router = express.Router();
 const DEFAULT_ACCESS_ROLES = ["Owner", "Admin", "Manager", "Viewer", "Disabled"];
 const REQUEST_CACHE_TTL_MS = 45000;
 const SEERR_MEDIA_DETAIL_CACHE_TTL_MS = 10 * 60 * 1000;
+const TDARR_TRANSCODE_CACHE_TTL_MS = 5000;
 const requestCache = new Map();
 const seerrMediaDetailCache = new Map();
+const tdarrTranscodeCache = new Map();
 const DEFAULT_ROLE_PERMISSIONS = {
   Owner: { dashboard: true, users: true, settings: true, apiKeys: true },
   Admin: { dashboard: true, users: true, settings: true, apiKeys: true },
@@ -46,6 +48,14 @@ const DEFAULT_ROLE_PERMISSIONS = {
   Viewer: { dashboard: true, users: false, settings: false, apiKeys: false },
   Disabled: { dashboard: false, users: false, settings: false, apiKeys: false },
 };
+
+function normalizeAccessRoles(settings = {}) {
+  return settings.roles || DEFAULT_ACCESS_ROLES;
+}
+
+function roleExists(settings = {}, role) {
+  return normalizeAccessRoles(settings).includes(role);
+}
 const DEFAULT_NOTIFICATION_SETTINGS = {
   mode: "all",
   manualTaskToasts: true,
@@ -272,10 +282,13 @@ async function testArrIntegration(integration) {
   const isSeerr = name.includes("jellyseerr") || name.includes("overseerr");
   const isBazarr = name === "bazarr";
   const isLidarr = name === "lidarr";
+  const isProwlarr = name === "prowlarr";
   const apiPaths = isSeerr
     ? ["/api/v1/status"]
     : isBazarr
     ? ["/api/system/status", "/api/system/status?apikey=:apiKey"]
+    : isProwlarr
+    ? ["/api/v1/system/status"]
     : [isLidarr ? "/api/v1/system/status" : "/api/v3/system/status"];
 
   if (!url || !apiKey) {
@@ -356,11 +369,24 @@ function isWizarrIntegration(integration) {
   return name === "wizarr" || name.includes("wizarr");
 }
 
+function isTdarrIntegration(integration) {
+  const name = String(integration?.name || integration?.slug || "").toLowerCase();
+  return name === "tdarr" || name.includes("tdarr");
+}
+
 function getWizarrHeaders(integration) {
   const apiKey = integration?.values?.secret;
   return {
     Accept: "application/json",
     ...(apiKey ? { "X-API-Key": apiKey } : {}),
+  };
+}
+
+function getTdarrHeaders(integration) {
+  const apiKey = integration?.values?.secret;
+  return {
+    Accept: "application/json",
+    ...(apiKey ? { "x-api-key": apiKey } : {}),
   };
 }
 
@@ -384,14 +410,585 @@ async function testWizarrIntegration(integration) {
   };
 }
 
+async function testTdarrIntegration(integration) {
+  const url = cleanIntegrationUrl(integration.values?.url);
+
+  if (!url) {
+    return { ok: false, error: "URL is required" };
+  }
+
+  const [statusResponse, statistics] = await Promise.all([
+    axios.get(`${url}/api/v2/status`, {
+      timeout: 10000,
+      headers: getTdarrHeaders(integration),
+    }),
+    fetchTdarrStatistics(integration),
+  ]);
+  const data = statusResponse.data || {};
+  const stats = normalizeTdarrStatistics(statistics);
+  const version = extractIntegrationVersion(data) || data?.serverVersion || data?.tdarrVersion || "Tdarr API";
+  return {
+    ok: true,
+    version,
+    message: `${stats.queue} queued · ${stats.processed} processed · ${stats.errored} errored`,
+  };
+}
+
 async function testThirdPartyIntegration(integration) {
   if (isWizarrIntegration(integration)) {
     return testWizarrIntegration(integration);
+  }
+  if (isTdarrIntegration(integration)) {
+    return testTdarrIntegration(integration);
   }
   return {
     ok: true,
     version: "saved credentials",
     message: "Connected to saved credentials",
+  };
+}
+
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== "");
+}
+
+function asArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function toNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function pickArray(root, names) {
+  if (!root || typeof root !== "object") return [];
+  for (const name of names) {
+    const value = root[name];
+    if (Array.isArray(value)) return value;
+    if (value && typeof value === "object") {
+      const nested = Object.values(value).find(Array.isArray);
+      if (nested) return nested;
+    }
+  }
+  return [];
+}
+
+function flattenRecordCollections(root, names) {
+  const direct = pickArray(root, names);
+  if (direct.length) return direct;
+  const results = [];
+  for (const value of Object.values(root || {})) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const nested = pickArray(value, names);
+      if (nested.length) results.push(...nested);
+    }
+  }
+  return results;
+}
+
+function recursivelyFindArrays(root, predicate, maxDepth = 4) {
+  const results = [];
+  const seen = new WeakSet();
+
+  function visit(value, depth) {
+    if (!value || typeof value !== "object" || depth > maxDepth || seen.has(value)) return;
+    seen.add(value);
+    if (Array.isArray(value)) {
+      if (!predicate || value.some((item) => item && typeof item === "object" && predicate(item))) {
+        results.push(value);
+      }
+      value.forEach((item) => visit(item, depth + 1));
+      return;
+    }
+    Object.values(value).forEach((item) => visit(item, depth + 1));
+  }
+
+  visit(root, 0);
+  return results.flat();
+}
+
+function extractTdarrTitle(record = {}) {
+  const sourceRecord = record.originalLibraryFile || record.libraryFile || record.file || record;
+  const rawPath = firstDefined(sourceRecord.filePath, sourceRecord.file, sourceRecord.path, record.filePath, record.file, record.path, record.inputFile, record.originalPath, record._id, "");
+  const rawTitle = firstDefined(
+    sourceRecord.fileNameWithoutExtension,
+    sourceRecord.title,
+    sourceRecord.name,
+    record.title,
+    record.name,
+    record.fileName,
+    record.originalFileName,
+    record.meta?.Title,
+    record.DB?.Title,
+    record._source?.fileName,
+    ""
+  );
+  const fromPath = String(rawPath || "")
+    .split(/[\\/]/)
+    .pop()
+    ?.replace(/\.[^.]+$/, "");
+  return String(rawTitle || fromPath || "Unknown media");
+}
+
+function normalizeTdarrDisplayStatus(value) {
+  const text = String(value || "").trim();
+  if (!text || text.toLowerCase() === "none") return "";
+  return text;
+}
+
+function parseTdarrTargetFromText(value) {
+  const text = String(value || "").toLowerCase();
+  if (!text || text === "none") return "";
+
+  const codec = text.match(/\b(hevc|h265|h\.265|x265|av1|h264|h\.264|x264|vp9)\b/)?.[1];
+  const container = text.match(/\b(mkv|mp4|mov|avi|webm)\b/)?.[1];
+  const resolution = text.match(/\b(2160p|4k|1440p|1080p|720p|576p|480p)\b/)?.[1];
+  const parts = [
+    codec?.replace("h.265", "h265").replace("x265", "h265").replace("h.264", "h264").replace("x264", "h264"),
+    container,
+    resolution === "4k" ? "2160p" : resolution,
+  ].filter(Boolean);
+
+  return parts.length ? [...new Set(parts)].join(" / ") : "";
+}
+
+function getTdarrFormatLabel(record = {}) {
+  return [
+    firstDefined(record.video_codec_name, record.videoCodec, record.codec),
+    firstDefined(record.container, record.format),
+    firstDefined(record.video_resolution, record.resolution),
+  ]
+    .map(normalizeTdarrDisplayStatus)
+    .filter(Boolean)
+    .join(" / ");
+}
+
+function tdarrSizeToBytes(value, unit = "gb") {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) return 0;
+  if (unit === "mb") return number * 1000000;
+  if (unit === "bytes") return number;
+  return number * 1000000000;
+}
+
+function getTdarrTargetLabel(record = {}, status = "queued") {
+  const base = record.originalLibraryFile || record.libraryFile || record;
+  const output = record.output || record.target || record.result || {};
+  const directParts = [
+    firstDefined(record.targetCodec, record.outputCodec, output.videoCodec, output.video_codec_name),
+    firstDefined(record.targetContainer, record.outputContainer, output.container),
+    firstDefined(record.targetResolution, record.outputResolution, output.video_resolution),
+  ].map(normalizeTdarrDisplayStatus).filter(Boolean);
+
+  if (directParts.length) {
+    return [...new Set(directParts)].join(" / ");
+  }
+
+  const descriptiveTarget = firstDefined(record.pluginName, record.flowName, record.lastPluginDetails, base.lastPluginDetails);
+  const parsedTarget = parseTdarrTargetFromText(descriptiveTarget);
+  if (parsedTarget) return parsedTarget;
+
+  if (status === "queued") {
+    const isHealthCheck = String(firstDefined(record.HealthCheck, base.HealthCheck, "")).toLowerCase() === "queued";
+    return isHealthCheck ? "Health check" : "Queued target";
+  }
+
+  return status === "active" ? "Processing" : "";
+}
+
+function extractTdarrCodec(record = {}, side = "from") {
+  const base = record.originalLibraryFile || record.libraryFile || record;
+  const source = side === "from" ? record.input || record.source || record.original || base.mediaInfo || base : record.output || record.target || record.result || record.mediaInfo || record;
+  return firstDefined(
+    source.videoCodec,
+    source.video_codec_name,
+    source.codec,
+    source.container,
+    source.format,
+    record[side === "from" ? "originalCodec" : "targetCodec"],
+    record[side === "from" ? "sourceCodec" : "outputCodec"],
+    side === "from" ? record.video_codec_name : record.output_codec_name,
+    ""
+  );
+}
+
+function normalizeTdarrProgress(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 0;
+  return Math.max(0, Math.min(100, number > 1 ? number : number * 100));
+}
+
+function getTdarrExplicitProgress(record = {}) {
+  const candidates = [
+    record.progress,
+    record.percent,
+    record.percentage,
+    record.transcodePercent,
+    record.worker?.progress,
+    record.worker?.percent,
+    record.worker?.percentage,
+    record.job?.progress,
+    record.job?.percent,
+    record.job?.percentage,
+    record.process?.progress,
+    record.process?.percent,
+    record.process?.percentage,
+    record.ffmpeg?.progress,
+    record.ffmpeg?.percent,
+    record.ffmpeg?.percentage,
+  ];
+
+  const value = candidates.find((candidate) => candidate !== undefined && candidate !== null && candidate !== "");
+  return value === undefined ? 0 : normalizeTdarrProgress(value);
+}
+
+function normalizeTdarrRecord(record = {}, status = "queued", index = 0) {
+  const id = String(firstDefined(record.id, record._id, record.fileId, record.jobId, record.jobID, record.file, record.path, `${status}-${index}`));
+  const progress = getTdarrExplicitProgress(record);
+  const itemId = firstDefined(record.jellyfinId, record.jellyfinItemId, record.itemId, record.mediaId, record.embyId, record.meta?.Id, record.jellyglanceItemId, "");
+  const imageId = firstDefined(record.jellyglanceImageId, itemId);
+  const posterId = firstDefined(record.jellyglancePosterId, imageId, itemId);
+  const base = record.originalLibraryFile || record.libraryFile || record;
+  const sourceCodec = getTdarrFormatLabel(base);
+  const activeStatus = status === "active" ? firstDefined(record.status, record.handling, record.job?.type) : "";
+  const decision = normalizeTdarrDisplayStatus(firstDefined(activeStatus, record.TranscodeDecisionMaker, base.TranscodeDecisionMaker, record.HealthCheck, base.HealthCheck, status));
+  const targetLabel = getTdarrTargetLabel(record, status);
+  const reasonLabel = normalizeTdarrDisplayStatus(firstDefined(record.reason, record.error, record.message, record.pluginName, record.lastPluginDetails, base.lastPluginDetails));
+  const oldSizeBytes = tdarrSizeToBytes(firstDefined(record.oldSize, base.oldSize, record.originalSizeGb, base.originalSizeGb));
+  const newSizeBytes = tdarrSizeToBytes(firstDefined(record.newSize, base.newSize, record.outputSizeGb, base.outputSizeGb));
+  const fileSizeBytes = tdarrSizeToBytes(firstDefined(base.file_size, record.file_size), "mb");
+  const sizeBefore = firstDefined(record.sizeBefore, record.originalSize, record.input?.size, oldSizeBytes);
+  const sizeAfter = firstDefined(record.outputSize, record.sizeAfter, record.output?.size, newSizeBytes, fileSizeBytes);
+  const savedBytes = oldSizeBytes && newSizeBytes ? Math.max(0, oldSizeBytes - newSizeBytes) : 0;
+  const savedPercent = oldSizeBytes && savedBytes ? Math.round((savedBytes / oldSizeBytes) * 100) : 0;
+  const historyFrom = normalizeTdarrDisplayStatus(firstDefined(record.originalFormat, record.sourceFormat, record.previousFormat, ""));
+  const historyTo = sourceCodec || targetLabel;
+
+  return {
+    id,
+    title: extractTdarrTitle(record),
+    library: firstDefined(record.libraryName, record.library, base.DB, record.DB?.libraryName, record.meta?.LibraryName, ""),
+    worker: firstDefined(record.workerName, record.nodeName, record.nodeID, record.nodeId, record.worker?.name, record.workerType, ""),
+    status: decision || status,
+    from: status === "history" ? firstDefined(historyFrom, "Previous version") : firstDefined(sourceCodec, extractTdarrCodec(record, "from"), "Source"),
+    to: status === "history" ? firstDefined(historyTo, targetLabel, "After") : targetLabel,
+    progress,
+    sizeBefore,
+    sizeAfter,
+    savedBytes,
+    savedPercent,
+    updatedAt: firstDefined(record.updatedAt, record.lastUpdated, record.date, record.time, record.finishedAt, record.createdAt, base.lastTranscodeDate, base.lastHealthCheckDate, ""),
+    reason: reasonLabel,
+    itemId,
+    imageId,
+    bannerUrl: imageId ? `/proxy/Items/Images/Backdrop?id=${encodeURIComponent(imageId)}&fillWidth=1200&quality=64` : "",
+    thumbnailUrl: posterId ? `/proxy/Items/Images/Primary?id=${encodeURIComponent(posterId)}&fillWidth=480&fillHeight=720&quality=96` : "",
+  };
+}
+
+function getTdarrRecordPath(record = {}) {
+  const base = record.originalLibraryFile || record.libraryFile || record;
+  return firstDefined(base.file, base.path, base.filePath, record.file, record.path, record.filePath, record._id, "");
+}
+
+function getTdarrPathSuffix(pathValue = "") {
+  const parts = String(pathValue).split(/[\\/]+/).filter(Boolean);
+  if (parts.length <= 3) return parts.join("/");
+  return parts.slice(-4).join("/");
+}
+
+function getTdarrEpisodeKey(pathValue = "") {
+  const text = String(pathValue);
+  const episodeMatch = text.match(/S(\d{1,2})E(\d{1,3})/i);
+  if (!episodeMatch) return null;
+  const parts = text.split(/[\\/]+/).filter(Boolean);
+  const seriesFolder = parts.find((part) => /\(\d{4}\)/.test(part)) || parts[Math.max(0, parts.length - 3)] || "";
+  return {
+    series: seriesFolder.toLowerCase(),
+    episode: `s${episodeMatch[1].padStart(2, "0")}e${episodeMatch[2].padStart(2, "0")}`,
+  };
+}
+
+async function attachJellyfinIdsToTdarrRecords(records = []) {
+  const paths = [...new Set(records.map(getTdarrRecordPath).filter(Boolean))];
+  if (!paths.length) return records;
+
+  try {
+    const suffixes = [...new Set(paths.map(getTdarrPathSuffix).filter(Boolean))];
+    const episodeKeys = new Map(paths.map((pathValue) => [pathValue, getTdarrEpisodeKey(pathValue)]).filter(([, key]) => key));
+    const episodeSeriesPatterns = [...new Set([...episodeKeys.values()].map((key) => `%${key.series}%`))];
+    const episodePatterns = [...new Set([...episodeKeys.values()].map((key) => key.episode.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))];
+    const { rows } = await db.query(
+      `
+        SELECT "Id", "Path", "Name"
+        FROM jf_item_info
+        WHERE "Path" = ANY($1)
+           OR "Path" LIKE ANY($2)
+           OR ("Path" ILIKE ANY($3) AND "Path" ~* ANY($4))
+      `,
+      [paths, suffixes.map((suffix) => `%${suffix}`), episodeSeriesPatterns.length ? episodeSeriesPatterns : ["__jg_no_series_match__"], episodePatterns.length ? episodePatterns : ["__jg_no_episode_match__"]]
+    );
+    const idByPath = new Map(rows.map((row) => [row.Path, row.Id]));
+    const idBySuffix = new Map(rows.map((row) => [getTdarrPathSuffix(row.Path), row.Id]));
+    const idByEpisode = new Map(
+      rows
+        .map((row) => {
+          const key = getTdarrEpisodeKey(row.Path || row.Name);
+          return key ? [`${key.series}::${key.episode}`, row.Id] : null;
+        })
+        .filter(Boolean)
+    );
+    const matchedItemIds = [...new Set(
+      records
+        .map((record) => {
+          const pathValue = getTdarrRecordPath(record);
+          const episodeKey = episodeKeys.get(pathValue);
+          return (
+            idByPath.get(pathValue) ||
+            idBySuffix.get(getTdarrPathSuffix(pathValue)) ||
+            (episodeKey ? idByEpisode.get(`${episodeKey.series}::${episodeKey.episode}`) : null)
+          );
+        })
+        .filter(Boolean)
+    )];
+    const imageIdByItemId = new Map();
+    const posterIdByItemId = new Map();
+    if (matchedItemIds.length) {
+      const episodeRows = await db.query(
+        'SELECT "EpisodeId", "SeriesId", "ParentBackdropItemId" FROM jf_library_episodes WHERE "EpisodeId" = ANY($1)',
+        [matchedItemIds]
+      );
+      episodeRows.rows.forEach((row) => {
+        imageIdByItemId.set(row.EpisodeId, row.ParentBackdropItemId || row.SeriesId);
+        posterIdByItemId.set(row.EpisodeId, row.SeriesId);
+      });
+    }
+
+    return records.map((record) => {
+      const pathValue = getTdarrRecordPath(record);
+      const episodeKey = episodeKeys.get(pathValue);
+      const itemId =
+        idByPath.get(pathValue) ||
+        idBySuffix.get(getTdarrPathSuffix(pathValue)) ||
+        (episodeKey ? idByEpisode.get(`${episodeKey.series}::${episodeKey.episode}`) : null);
+      return itemId
+        ? {
+            ...record,
+            jellyglanceItemId: itemId,
+            jellyglanceImageId: imageIdByItemId.get(itemId) || itemId,
+            jellyglancePosterId: posterIdByItemId.get(itemId) || itemId,
+          }
+        : record;
+    });
+  } catch (error) {
+    console.log("Tdarr Jellyfin path lookup failed:", error.message);
+    return records;
+  }
+}
+
+function normalizeTdarrStatistics(statistics = {}) {
+  const table1 = toNumber(statistics.table1ViewableCount ?? statistics.table1Count);
+  const table2 = toNumber(statistics.table2ViewableCount ?? statistics.table2Count);
+  const table3 = toNumber(statistics.table3ViewableCount ?? statistics.table3Count);
+  const table4 = toNumber(statistics.table4ViewableCount ?? statistics.table4Count);
+  const table5 = toNumber(statistics.table5ViewableCount ?? statistics.table5Count);
+  const table6 = toNumber(statistics.table6ViewableCount ?? statistics.table6Count);
+  return {
+    transcodeQueue: table1,
+    transcodeProcessed: table2,
+    transcodeErrored: table3,
+    healthQueue: table4,
+    healthProcessed: table5,
+    healthErrored: table6,
+    queue: table1 + table4,
+    processed: table2 + table5,
+    errored: table3 + table6,
+    saved: toNumber(statistics.sizeDiff) * 1000000000,
+  };
+}
+
+function looksLikeTdarrActiveRecord(record = {}) {
+  const text = [
+    record.status,
+    record.state,
+    record.stage,
+    record.type,
+    record.workerType,
+    record.process,
+    record.file,
+    record.filePath,
+    record.originalPath,
+    record.healthCheck,
+    record.transcode,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return /transcod|health|worker|process|ffmpeg|handbrake|active|running|current|file/.test(text);
+}
+
+function isTdarrQueuedFile(file = {}) {
+  return [file.TranscodeDecisionMaker, file.HealthCheck].some((value) => String(value || "").toLowerCase() === "queued");
+}
+
+function isTdarrHistoryFile(file = {}) {
+  return [file.TranscodeDecisionMaker, file.HealthCheck].some((value) => /success|error|cancel|not required|complete/i.test(String(value || "")));
+}
+
+function sortTdarrFilesByDate(files = []) {
+  return [...files].sort((first, second) => {
+    const firstDate = toNumber(first.lastTranscodeDate || first.lastHealthCheckDate || first.createdAt);
+    const secondDate = toNumber(second.lastTranscodeDate || second.lastHealthCheckDate || second.createdAt);
+    return secondDate - firstDate;
+  });
+}
+
+function extractTdarrActiveRows(root = {}) {
+  const namedRows = flattenRecordCollections(root, [
+    "active",
+    "activeTranscodes",
+    "activeWorkers",
+    "workers",
+    "currentTranscodes",
+    "running",
+    "inProgress",
+    "transcodeWorkers",
+    "nodeStatus",
+    "nodes",
+  ]);
+  const recursiveRows = recursivelyFindArrays(root, looksLikeTdarrActiveRecord, 4);
+  const rows = [...namedRows, ...recursiveRows].filter((record) => record && typeof record === "object" && looksLikeTdarrActiveRecord(record));
+  const seen = new Set();
+  return rows.filter((record) => {
+    const key = String(firstDefined(record.id, record._id, record.file, record.filePath, record.workerName, record.nodeName, JSON.stringify(record).slice(0, 160)));
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function normalizeTdarrBundle(data = {}, statistics = {}, stagedRows = [], fileRows = []) {
+  const root = data.data && typeof data.data === "object" ? data.data : data;
+  const queuedNames = ["queued", "queue", "transcodeQueue", "transcodeQueueItems", "staged", "pending", "waiting"];
+  const historyNames = ["history", "recent", "recentlyFinished", "finished", "success", "completed", "transcodeHistory"];
+  const normalizedStats = normalizeTdarrStatistics(statistics);
+  const staged = Array.isArray(stagedRows) ? stagedRows : [];
+  const files = Array.isArray(fileRows) ? fileRows : [];
+  const activeSource = staged.length ? staged : extractTdarrActiveRows(root);
+  const queuedSource = files.length ? files.filter(isTdarrQueuedFile).slice(0, 80) : flattenRecordCollections(root, queuedNames);
+  const historySource = files.length ? sortTdarrFilesByDate(files.filter(isTdarrHistoryFile)).slice(0, 80) : flattenRecordCollections(root, historyNames);
+  const active = activeSource.map((record, index) => normalizeTdarrRecord(record, "active", index));
+  const queued = queuedSource.map((record, index) => normalizeTdarrRecord(record, "queued", index));
+  const history = historySource.map((record, index) => normalizeTdarrRecord(record, "history", index));
+
+  return {
+    source: {
+      name: "Tdarr",
+      version: extractIntegrationVersion(data) || root.serverVersion || root.tdarrVersion || "",
+    },
+    active,
+    queued,
+    history,
+    stats: {
+      active: staged.length || getTdarrActiveCount(active, root),
+      queued: normalizedStats.queue || queued.length || toNumber(root.totalQueued || root.queueCount || root.transcodeQueueCount),
+      queue: normalizedStats.queue || queued.length || toNumber(root.totalQueued || root.queueCount || root.transcodeQueueCount),
+      processed: normalizedStats.processed,
+      errored: normalizedStats.errored,
+      saved: normalizedStats.saved,
+      transcodeQueue: normalizedStats.transcodeQueue,
+      healthQueue: normalizedStats.healthQueue,
+      history: history.length || normalizedStats.processed + normalizedStats.errored,
+      nodes: asArray(root.nodes || root.nodeStatus || root.clients).length,
+    },
+    raw: root,
+    statistics,
+    syncedAt: new Date().toISOString(),
+  };
+}
+
+function getTdarrActiveCount(active = [], data = {}) {
+  const explicit = firstDefined(data.activeCount, data.activeTranscodeCount, data.transcodeCount, data.stats?.active, data.workerStats?.active);
+  const number = Number(explicit);
+  return Number.isFinite(number) ? number : active.length;
+}
+
+async function getConnectedTdarrIntegration() {
+  const integrations = await getIntegrations();
+  return (integrations.thirdParty || []).find((integration) => integration.connected && isTdarrIntegration(integration));
+}
+
+async function fetchTdarrCrudDb(integration, payload) {
+  const url = cleanIntegrationUrl(integration.values?.url);
+  const response = await axios.post(`${url}/api/v2/cruddb`, payload, {
+    timeout: 12000,
+    headers: {
+      ...getTdarrHeaders(integration),
+      "Content-Type": "application/json",
+    },
+  });
+  return response.data || {};
+}
+
+async function fetchTdarrStatistics(integration) {
+  try {
+    return await fetchTdarrCrudDb(integration, {
+      data: {
+        collection: "StatisticsJSONDB",
+        mode: "getById",
+        docID: "statistics",
+      },
+    });
+  } catch (error) {
+    console.log("Tdarr statistics load failed:", getAxiosErrorMessage(error));
+    return {};
+  }
+}
+
+async function fetchTdarrCollection(integration, collection) {
+  try {
+    const data = await fetchTdarrCrudDb(integration, {
+      data: {
+        collection,
+        mode: "getAll",
+      },
+    });
+    return Array.isArray(data) ? data : [];
+  } catch (error) {
+    console.log(`Tdarr ${collection} load failed:`, getAxiosErrorMessage(error));
+    return [];
+  }
+}
+
+async function fetchTdarrBundle(integration) {
+  const url = cleanIntegrationUrl(integration.values?.url);
+  const [statusResponse, statistics, stagedRows, fileRows] = await Promise.all([
+    axios.get(`${url}/api/v2/status`, {
+      timeout: 12000,
+      headers: getTdarrHeaders(integration),
+    }),
+    fetchTdarrStatistics(integration),
+    fetchTdarrCollection(integration, "StagedJSONDB"),
+    fetchTdarrCollection(integration, "FileJSONDB"),
+  ]);
+  const queuedFiles = fileRows.filter(isTdarrQueuedFile).slice(0, 80);
+  const historyFiles = sortTdarrFilesByDate(fileRows.filter(isTdarrHistoryFile)).slice(0, 80);
+  const [activeWithImages, queuedWithImages, historyWithImages] = await Promise.all([
+    attachJellyfinIdsToTdarrRecords(stagedRows),
+    attachJellyfinIdsToTdarrRecords(queuedFiles),
+    attachJellyfinIdsToTdarrRecords(historyFiles),
+  ]);
+  const bundle = normalizeTdarrBundle(statusResponse.data || {}, statistics, activeWithImages, [...queuedWithImages, ...historyWithImages]);
+  return {
+    ...bundle,
+    source: {
+      ...bundle.source,
+      name: integration.name || "Tdarr",
+      url,
+      instanceId: integration.instanceId,
+    },
   };
 }
 
@@ -568,6 +1165,203 @@ async function fetchWizarrBundle(integration) {
 function isSeerrIntegration(integration) {
   const name = String(integration?.name || integration?.slug || "").toLowerCase();
   return name === "seerr" || name.includes("jellyseerr") || name.includes("overseerr");
+}
+
+function isBazarrIntegration(integration) {
+  const name = String(integration?.name || integration?.slug || "").toLowerCase();
+  return name === "bazarr" || name.includes("bazarr");
+}
+
+function isProwlarrIntegration(integration) {
+  const name = String(integration?.name || integration?.slug || "").toLowerCase();
+  return name === "prowlarr" || name.includes("prowlarr");
+}
+
+function getArrHeaders(integration) {
+  return {
+    Accept: "application/json",
+    "X-Api-Key": integration?.values?.secret || "",
+  };
+}
+
+function asCount(value) {
+  if (Array.isArray(value)) return value.length;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function toStatusText(value) {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  return value.message || value.errorMessage || value.error || JSON.stringify(value);
+}
+
+async function fetchOptionalJson(url, options) {
+  try {
+    const response = await axios.get(url, options);
+    return response.data;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeBazarrHistory(items = []) {
+  return (Array.isArray(items) ? items : items?.data || [])
+    .map((item, index) => ({
+      id: item.id || item.history_id || `${item.title || item.path || "subtitle"}-${index}`,
+      title: item.title || item.seriesTitle || item.movieTitle || item.sonarrSeriesTitle || item.radarrMovieTitle || item.path || "Subtitle event",
+      language: item.language || item.languageName || item.subtitle_language || "",
+      action: item.action || item.event || (item.upgrade ? "Upgraded" : item.message || "Subtitle update"),
+      provider: item.provider || item.score_provider || "",
+      createdAt: item.timestamp || item.date || item.createdAt || "",
+    }))
+    .slice(0, 20);
+}
+
+async function fetchBazarrHealth(integration) {
+  const url = cleanIntegrationUrl(integration.values?.url);
+  const headers = getArrHeaders(integration);
+  const options = { timeout: 12000, headers, params: { apikey: integration.values?.secret } };
+  const [status, health, episodesWanted, moviesWanted, history] = await Promise.all([
+    fetchOptionalJson(`${url}/api/system/status`, options),
+    fetchOptionalJson(`${url}/api/system/health`, options),
+    fetchOptionalJson(`${url}/api/episodes/wanted`, options),
+    fetchOptionalJson(`${url}/api/movies/wanted`, options),
+    fetchOptionalJson(`${url}/api/history`, options),
+  ]);
+  const episodeItems = Array.isArray(episodesWanted) ? episodesWanted : episodesWanted?.data || episodesWanted?.results || [];
+  const movieItems = Array.isArray(moviesWanted) ? moviesWanted : moviesWanted?.data || moviesWanted?.results || [];
+  const issues = Array.isArray(health) ? health : health?.issues || health?.data || [];
+
+  return {
+    id: integration.instanceId,
+    name: integration.name || "Bazarr",
+    type: "bazarr",
+    version: extractIntegrationVersion(status) || status?.version || "",
+    ok: issues.length === 0,
+    stats: {
+      missingEpisodes: asCount(episodeItems),
+      missingMovies: asCount(movieItems),
+      issues: issues.length,
+      recentDownloads: normalizeBazarrHistory(history).length,
+    },
+    issues: issues.map((issue, index) => ({
+      id: issue.id || index,
+      source: issue.source || issue.type || "Bazarr",
+      message: toStatusText(issue.message || issue.error || issue.warning || issue),
+      level: issue.type || issue.level || "warning",
+    })),
+    wanted: [...episodeItems, ...movieItems].slice(0, 20).map((item, index) => ({
+      id: item.id || item.sonarrEpisodeId || item.radarrId || index,
+      title: item.title || item.seriesTitle || item.movieTitle || item.path || "Missing subtitle",
+      language: item.language || item.languageName || item.missing_language || "",
+      type: item.episodeTitle || item.seriesTitle ? "Episode" : "Movie",
+    })),
+    history: normalizeBazarrHistory(history),
+  };
+}
+
+async function fetchProwlarrHealth(integration) {
+  const url = cleanIntegrationUrl(integration.values?.url);
+  const headers = getArrHeaders(integration);
+  const options = { timeout: 12000, headers };
+  const [status, health, indexers, indexerStatus, applications] = await Promise.all([
+    fetchOptionalJson(`${url}/api/v1/system/status`, options),
+    fetchOptionalJson(`${url}/api/v1/health`, options),
+    fetchOptionalJson(`${url}/api/v1/indexer`, options),
+    fetchOptionalJson(`${url}/api/v1/indexerstatus`, options),
+    fetchOptionalJson(`${url}/api/v1/applications`, options),
+  ]);
+  const indexerRows = Array.isArray(indexers) ? indexers : [];
+  const statusRows = Array.isArray(indexerStatus) ? indexerStatus : [];
+  const issueRows = Array.isArray(health) ? health : [];
+  const statusByIndexerId = new Map(statusRows.map((item) => [String(item.indexerId || item.id), item]));
+  const failedIndexers = indexerRows.filter((indexer) => {
+    const row = statusByIndexerId.get(String(indexer.id));
+    return indexer.enable === false || row?.disabledTill || row?.mostRecentFailure || row?.initialFailure;
+  });
+
+  return {
+    id: integration.instanceId,
+    name: integration.name || "Prowlarr",
+    type: "prowlarr",
+    version: extractIntegrationVersion(status) || status?.version || "",
+    ok: issueRows.length === 0 && failedIndexers.length === 0,
+    stats: {
+      indexers: indexerRows.length,
+      failedIndexers: failedIndexers.length,
+      applications: Array.isArray(applications) ? applications.length : 0,
+      issues: issueRows.length,
+    },
+    issues: [
+      ...issueRows.map((issue, index) => ({
+        id: issue.id || index,
+        source: issue.source || "Prowlarr",
+        message: toStatusText(issue.message || issue.error || issue),
+        level: issue.type || issue.level || "warning",
+      })),
+      ...failedIndexers.map((indexer) => {
+        const row = statusByIndexerId.get(String(indexer.id)) || {};
+        return {
+          id: `indexer-${indexer.id}`,
+          source: indexer.name || "Indexer",
+          message: toStatusText(row.mostRecentFailure || row.initialFailure || row.disabledTill || "Indexer disabled"),
+          level: "error",
+        };
+      }),
+    ],
+    indexers: indexerRows.slice(0, 40).map((indexer) => {
+      const row = statusByIndexerId.get(String(indexer.id)) || {};
+      return {
+        id: indexer.id,
+        name: indexer.name || `Indexer ${indexer.id}`,
+        protocol: indexer.protocol || "",
+        enabled: indexer.enable !== false,
+        failure: toStatusText(row.mostRecentFailure || row.initialFailure),
+        disabledTill: toStatusText(row.disabledTill),
+      };
+    }),
+    applications: (Array.isArray(applications) ? applications : []).map((app) => ({
+      id: app.id,
+      name: app.name || app.implementationName || "Application",
+      syncLevel: app.syncLevel || "",
+      tags: app.tags || [],
+    })),
+  };
+}
+
+async function fetchAutomationHealth() {
+  const integrations = await getIntegrations();
+  const apps = (integrations.arrApps || []).filter((integration) => integration.connected && (isBazarrIntegration(integration) || isProwlarrIntegration(integration)));
+  const results = await Promise.allSettled(
+    apps.map((integration) => (isBazarrIntegration(integration) ? fetchBazarrHealth(integration) : fetchProwlarrHealth(integration)))
+  );
+
+  const services = results.map((result, index) => {
+    if (result.status === "fulfilled") return result.value;
+    const integration = apps[index];
+    return {
+      id: integration.instanceId,
+      name: integration.name,
+      type: isBazarrIntegration(integration) ? "bazarr" : "prowlarr",
+      ok: false,
+      stats: {},
+      issues: [{ id: "load-error", source: integration.name, message: getAxiosErrorMessage(result.reason), level: "error" }],
+    };
+  });
+
+  return {
+    services,
+    stats: {
+      services: services.length,
+      healthy: services.filter((service) => service.ok).length,
+      issues: services.reduce((count, service) => count + (service.issues?.length || 0), 0),
+      missingSubtitles: services.reduce((count, service) => count + Number(service.stats?.missingEpisodes || 0) + Number(service.stats?.missingMovies || 0), 0),
+      failedIndexers: services.reduce((count, service) => count + Number(service.stats?.failedIndexers || 0), 0),
+    },
+    syncedAt: new Date().toISOString(),
+  };
 }
 
 function cloneJson(value) {
@@ -1462,6 +2256,7 @@ async function normalizeSeerrRequest(item, source, options = {}) {
 
 function buildRequestStats(requests = []) {
   const realRequests = requests.filter((request) => request.status !== "Error");
+  const now = Date.now();
   const statusCounts = realRequests.reduce((counts, request) => {
     const status = request.status || "Unknown";
     counts[status] = (counts[status] || 0) + 1;
@@ -1487,6 +2282,45 @@ function buildRequestStats(requests = []) {
     .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type))[0] || { type: "none", count: 0 };
   const failed = (statusCounts.Failed || 0) + requests.filter((request) => request.status === "Error").length;
   const pending = statusCounts.Pending || 0;
+  const approvalQueue = realRequests
+    .filter((request) => request.status === "Pending")
+    .sort((a, b) => new Date(a.createdAt || 0) - new Date(b.createdAt || 0))
+    .slice(0, 8)
+    .map((request) => ({
+      id: request.id,
+      title: request.title,
+      requester: request.requestedBy,
+      source: request.source,
+      createdAt: request.createdAt,
+    }));
+  const perUserPending = Object.entries(
+    realRequests
+      .filter((request) => request.status === "Pending")
+      .reduce((counts, request) => {
+        const requester = request.requestedBy || "Unknown user";
+        counts[requester] = (counts[requester] || 0) + 1;
+        return counts;
+      }, {})
+  )
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .slice(0, 5);
+  const mediaIssues = realRequests
+    .filter((request) => ["Failed", "Missing", "Partially available"].includes(request.status) || ["Missing", "Partially available"].includes(request.availability?.status))
+    .slice(0, 8)
+    .map((request) => ({
+      id: request.id,
+      title: request.title,
+      status: request.status,
+      availability: request.availability?.status || "Unknown",
+      source: request.source,
+    }));
+  const trends = Array.from({ length: 7 }).map((_, offset) => {
+    const date = new Date(now - (6 - offset) * 24 * 60 * 60 * 1000);
+    const key = date.toISOString().slice(0, 10);
+    const count = realRequests.filter((request) => String(request.createdAt || "").slice(0, 10) === key).length;
+    return { date: key, count };
+  });
 
   return {
     total: realRequests.length,
@@ -1497,6 +2331,10 @@ function buildRequestStats(requests = []) {
     failed,
     badgeCount: pending + failed,
     topRequesters,
+    perUserPending,
+    approvalQueue,
+    mediaIssues,
+    trends,
     mediaTypeCounts,
     mostRequestedMediaType,
   };
@@ -1570,6 +2408,64 @@ async function fetchSeerrRequests(options = {}) {
     requestCache.delete(cacheKey);
     throw error;
   }
+}
+
+function normalizeRequestOwnerValue(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function getRequestOwnerCandidates(user = {}) {
+  if (!user || user === "internal") return [];
+  return [
+    user.id,
+    user.username,
+    user.email,
+    user.name,
+    user.jellyfinUser?.id,
+    user.jellyfinUser?.Id,
+    user.jellyfinUser?.name,
+    user.jellyfinUser?.Name,
+    user.jellyfinUser?.username,
+    user.jellyfinUser?.UserName,
+  ]
+    .map(normalizeRequestOwnerValue)
+    .filter(Boolean);
+}
+
+function isUserRequestOwner(request, ownerCandidates = []) {
+  if (!ownerCandidates.length) return false;
+  const requester = request?.requester || {};
+  const requestCandidates = [
+    request?.requestedBy,
+    requester.id,
+    requester.userId,
+    requester.jellyfinUserId,
+    requester.name,
+    requester.username,
+    requester.email,
+  ]
+    .map(normalizeRequestOwnerValue)
+    .filter(Boolean);
+
+  return requestCandidates.some((candidate) => ownerCandidates.includes(candidate));
+}
+
+function canViewAllRequests(user) {
+  return user === "internal" || ["Owner", "Admin"].includes(user?.role);
+}
+
+function filterSeerrRequestsForUser(data, user) {
+  if (canViewAllRequests(user)) {
+    return data;
+  }
+
+  const ownerCandidates = getRequestOwnerCandidates(user);
+  const requests = (data.requests || []).filter((request) => isUserRequestOwner(request, ownerCandidates));
+  return {
+    ...data,
+    requests,
+    stats: buildRequestStats(requests),
+  };
 }
 
 async function fetchSeerrRequestDetail({ sourceId, requestId }) {
@@ -2550,6 +3446,23 @@ router.get("/health", async (req, res) => {
   }
 });
 
+router.get("/home/operations", async (req, res) => {
+  try {
+    const [requestsResult, healthResult] = await Promise.allSettled([
+      fetchSeerrRequests({ force: req.query?.forceRequests === "true" }),
+      buildHealthStatus(),
+    ]);
+
+    res.send({
+      requests: requestsResult.status === "fulfilled" ? requestsResult.value : null,
+      health: healthResult.status === "fulfilled" ? healthResult.value : null,
+    });
+  } catch (error) {
+    console.error("Home operations failed:", error);
+    res.status(503).send({ error: "Unable to load home operations" });
+  }
+});
+
 router.get("/admin-audit", async (req, res) => {
   try {
     res.send(await getAuditLog());
@@ -2561,12 +3474,11 @@ router.get("/admin-audit", async (req, res) => {
 
 router.get("/requests", async (req, res) => {
   try {
-    res.send(
-      await fetchSeerrRequests({
-        force: req.query?.force === "true",
-        includeInterest: req.query?.includeInterest === "true",
-      })
-    );
+    const data = await fetchSeerrRequests({
+      force: req.query?.force === "true",
+      includeInterest: req.query?.includeInterest === "true",
+    });
+    res.send(filterSeerrRequestsForUser(data, req.user));
   } catch (error) {
     console.error("Get Seerr requests failed:", error);
     res.status(503).send({ error: "Unable to load requests" });
@@ -2576,7 +3488,8 @@ router.get("/requests", async (req, res) => {
 router.get("/requests/summary", async (req, res) => {
   try {
     const data = await fetchSeerrRequests({ lightweight: true, force: req.query?.force === "true" });
-    res.send({ stats: data.stats, sources: data.sources, syncedAt: data.syncedAt });
+    const filtered = filterSeerrRequestsForUser(data, req.user);
+    res.send({ stats: filtered.stats, sources: filtered.sources, syncedAt: filtered.syncedAt });
   } catch (error) {
     console.error("Get Seerr request summary failed:", error);
     res.status(503).send({ error: "Unable to load request summary" });
@@ -2616,9 +3529,22 @@ router.get("/requests/options", async (req, res) => {
   }
 });
 
+router.get("/automation-health", async (req, res) => {
+  try {
+    res.send(await fetchAutomationHealth());
+  } catch (error) {
+    console.error("Automation health failed:", error);
+    res.status(error.statusCode || 503).send({ error: error.message || "Unable to load automation health" });
+  }
+});
+
 router.get("/requests/:requestId/detail", async (req, res) => {
   try {
-    res.send(await fetchSeerrRequestDetail({ requestId: req.params.requestId, sourceId: req.query?.sourceId }));
+    const request = await fetchSeerrRequestDetail({ requestId: req.params.requestId, sourceId: req.query?.sourceId });
+    if (!canViewAllRequests(req.user) && !isUserRequestOwner(request, getRequestOwnerCandidates(req.user))) {
+      return res.status(404).send({ error: "Request not found" });
+    }
+    res.send(request);
   } catch (error) {
     console.error("Seerr request detail failed:", error);
     res.status(error.statusCode || 503).send({ error: error.message || "Unable to load request detail" });
@@ -3475,6 +4401,16 @@ router.patch("/roles/:role/permissions", async (req, res) => {
       return;
     }
 
+    if (role === "Owner") {
+      res.json({ role, permissions: DEFAULT_ROLE_PERMISSIONS.Owner });
+      return;
+    }
+
+    if (role === "Disabled") {
+      res.json({ role, permissions: DEFAULT_ROLE_PERMISSIONS.Disabled });
+      return;
+    }
+
     settings.rolePermissions = {
       ...(settings.rolePermissions || {}),
       [role]: {
@@ -3507,6 +4443,12 @@ router.post("/localUsers", async (req, res) => {
     const config = await new configClass().getConfig();
     const settings = config.settings || {};
     const localUsers = settings.localUsers || [];
+    const cleanRole = role || "Viewer";
+
+    if (!roleExists(settings, cleanRole)) {
+      res.status(400).json({ errorMessage: "Role not found" });
+      return;
+    }
 
     if (config.APP_USER === username || localUsers.some((user) => user.username === username)) {
       res.status(409).json({ errorMessage: "A local user with that username already exists" });
@@ -3517,7 +4459,7 @@ router.post("/localUsers", async (req, res) => {
       id: randomUUID(),
       username,
       password,
-      role: role || "Viewer",
+      role: cleanRole,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
@@ -3543,6 +4485,11 @@ router.patch("/localUsers/:id", async (req, res) => {
 
     if (userIndex === -1) {
       res.status(404).json({ errorMessage: "Local user not found" });
+      return;
+    }
+
+    if (role && !roleExists(settings, role)) {
+      res.status(400).json({ errorMessage: "Role not found" });
       return;
     }
 
@@ -3609,6 +4556,12 @@ router.patch("/userRoles/:userid", async (req, res) => {
 
     const config = await new configClass().getConfig();
     const settings = config.settings || {};
+
+    if (!roleExists(settings, role)) {
+      res.status(400).json({ errorMessage: "Role not found" });
+      return;
+    }
+
     settings.userRoles = {
       ...(settings.userRoles || {}),
       [userid]: role,
@@ -4002,6 +4955,16 @@ router.get("/CheckForUpdates/releases", async (req, res) => {
   } catch (error) {
     console.log(error);
     res.status(503).send({ error: "Unable to load release notes" });
+  }
+});
+
+router.get("/github/contributors", async (req, res) => {
+  try {
+    const result = await fetchGithubContributors();
+    res.send(result);
+  } catch (error) {
+    console.log(error);
+    res.status(503).send({ error: "Unable to load GitHub contributors" });
   }
 });
 
@@ -4410,6 +5373,8 @@ router.get("/getHistory", async (req, res) => {
   const sortField = groupedSortMap.find((item) => item.field === sort)?.column || "a.ActivityDateInserted";
 
   const values = [];
+  const settingsResult = await db.query('SELECT settings FROM app_config where "ID"=1').catch(() => ({ rows: [] }));
+  const excludedUsers = Array.isArray(settingsResult.rows?.[0]?.settings?.ExcludedUsers) ? settingsResult.rows[0].settings.ExcludedUsers : [];
 
   try {
     const cte = {
@@ -4491,6 +5456,16 @@ router.get("/getHistory", async (req, res) => {
     }
 
     query.values = values;
+
+    if (excludedUsers.length) {
+      query.where = query.where || [];
+      query.where.push({
+        column: "a.UserId",
+        operator: "<> ALL",
+        value: `($${query.values.length + 1}::text[])`,
+      });
+      query.values.push(excludedUsers);
+    }
 
     dbHelper.buildFilterList(query, filtersArray, filterFields);
     const result = await dbHelper.query(query);
@@ -5255,6 +6230,27 @@ router.delete("/wizarr/invitations/:id", async (req, res) => {
   } catch (error) {
     console.error("Wizarr invitation delete failed:", getAxiosErrorMessage(error));
     res.status(error.response?.status || 503).send({ error: getAxiosErrorMessage(error) || "Unable to delete Wizarr invitation" });
+  }
+});
+
+router.get("/tdarr/transcodes", async (req, res) => {
+  try {
+    const integration = await getConnectedTdarrIntegration();
+    if (!integration) {
+      return res.status(404).send({ error: "Connect Tdarr in Settings > Integrations first." });
+    }
+    const cacheKey = integration.instanceId || integration.name || cleanIntegrationUrl(integration.values?.url) || "tdarr";
+    const cached = tdarrTranscodeCache.get(cacheKey);
+    if (req.query?.force !== "true" && cached && Date.now() - cached.cachedAt < TDARR_TRANSCODE_CACHE_TTL_MS) {
+      return res.send(cached.data);
+    }
+
+    const bundle = await fetchTdarrBundle(integration);
+    tdarrTranscodeCache.set(cacheKey, { cachedAt: Date.now(), data: bundle });
+    res.send(bundle);
+  } catch (error) {
+    console.error("Tdarr transcodes load failed:", getAxiosErrorMessage(error));
+    res.status(error.response?.status || 503).send({ error: getAxiosErrorMessage(error) || "Unable to load Tdarr transcodes" });
   }
 });
 

--- a/apps/api/routes/auth.js
+++ b/apps/api/routes/auth.js
@@ -42,6 +42,10 @@ const DEFAULT_ROLE_PERMISSIONS = {
 };
 
 function getRolePermissions(settings, role) {
+  if (role === "Owner" || role === "Disabled") {
+    return DEFAULT_ROLE_PERMISSIONS[role];
+  }
+
   return {
     ...(DEFAULT_ROLE_PERMISSIONS[role] || DEFAULT_ROLE_PERMISSIONS.Viewer),
     ...((settings.rolePermissions || {})[role] || {}),

--- a/apps/api/routes/stats.js
+++ b/apps/api/routes/stats.js
@@ -199,6 +199,8 @@ router.get("/getLibraryOverview", async (req, res) => {
 
 router.get("/getHomeDashboard", async (req, res) => {
   try {
+    const settingsResult = await db.query('SELECT settings FROM app_config where "ID"=1').catch(() => ({ rows: [] }));
+    const excludedUsers = Array.isArray(settingsResult.rows?.[0]?.settings?.ExcludedUsers) ? settingsResult.rows[0].settings.ExcludedUsers : [];
     const [
       playbackTotals,
       peakHours,
@@ -260,10 +262,11 @@ router.get("/getHomeDashboard", async (req, res) => {
           COALESCE(sum(a."PlaybackDuration"), 0)::bigint AS "WatchSeconds"
         FROM jf_users u
         LEFT JOIN jf_playback_activity a ON a."UserId" = u."Id"
+        WHERE array_length($1::text[], 1) IS NULL OR u."Id" <> ALL($1::text[])
         GROUP BY u."Id", u."Name", u."PrimaryImageTag"
         ORDER BY count(a."Id") DESC, COALESCE(sum(a."PlaybackDuration"), 0) DESC, u."Name" ASC
         LIMIT 5
-      `),
+      `, [excludedUsers]),
       db.query(`
         WITH library_plays AS (
           SELECT

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -192,6 +192,12 @@ const authRateLimit = createRateLimiter({
   max: Number(process.env.AUTH_RATE_LIMIT_MAX || 60),
   message: "Too many authentication requests. Try again later.",
 });
+function authRateLimitUnlessPublicStatus(req, res, next) {
+  if (req.method === "GET" && req.path === "/isConfigured") {
+    return next();
+  }
+  return authRateLimit(req, res, next);
+}
 const taskRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
   max: Number(process.env.TASK_RATE_LIMIT_MAX || 20),
@@ -329,7 +335,7 @@ app.use((req, res, next) => {
 });
 
 // initiate routes
-app.use(`/auth`, authRateLimit, authRouter, () => {
+app.use(`/auth`, authRateLimitUnlessPublicStatus, authRouter, () => {
   /*  #swagger.tags = ['Auth'] */
 }); // mount the API router at /auth
 app.use("/proxy", proxyRouter, () => {
@@ -501,6 +507,10 @@ function getTokenPermissions(user) {
 }
 
 function getRolePermissions(settings, role) {
+  if (role === "Owner" || role === "Disabled") {
+    return DEFAULT_ROLE_PERMISSIONS[role];
+  }
+
   return {
     ...(DEFAULT_ROLE_PERMISSIONS[role] || DEFAULT_ROLE_PERMISSIONS.Viewer),
     ...((settings.rolePermissions || {})[role] || {}),

--- a/apps/api/tasks/IntegrationHealthCheckTask.js
+++ b/apps/api/tasks/IntegrationHealthCheckTask.js
@@ -6,8 +6,9 @@ async function runIntegrationHealthCheckTask() {
   try {
     const integrations = await getIntegrations();
     const allIntegrations = [...(integrations.arrApps || []), ...(integrations.clients || []), ...(integrations.thirdParty || [])];
+    const allowsOptionalSecret = (item) => String(item?.name || item?.slug || "").toLowerCase().includes("tdarr");
     const missingConfig = allIntegrations
-      .filter((item) => !item.values?.url || !item.values?.secret || item.connected === false)
+      .filter((item) => !item.values?.url || (!allowsOptionalSecret(item) && !item.values?.secret) || item.connected === false)
       .map((item) => item.name);
 
     const webhookManager = new WebhookManager();

--- a/apps/api/version-control.js
+++ b/apps/api/version-control.js
@@ -13,6 +13,7 @@ const RELEASES_ATOM_URL = `${RELEASES_URL}.atom`;
 const RELEASE_CACHE_TTL_MS = Number(process.env.JS_RELEASE_CACHE_TTL_MS || 6 * 60 * 60 * 1000);
 const RELEASE_CACHE_MAX_STALE_MS = Number(process.env.JS_RELEASE_CACHE_MAX_STALE_MS || 14 * 24 * 60 * 60 * 1000);
 const RELEASE_CACHE_FILE = path.join(getConfigDir(), "release-notes-cache.json");
+const CONTRIBUTORS_CACHE_FILE = path.join(getConfigDir(), "github-contributors-cache.json");
 const BUNDLED_RELEASE_NOTES_FILE = path.join(__dirname, "../web/src/whats-new.json");
 
 function normalizeVersion(version) {
@@ -103,6 +104,21 @@ function normalizeRelease(release) {
   };
 }
 
+function isBotContributor(contributor) {
+  const login = String(contributor?.login || contributor?.name || "").toLowerCase();
+  return contributor?.type === "Bot" || /\bbot\b/.test(login) || login.includes("[bot]") || login.includes("dependabot") || login.includes("github-actions");
+}
+
+function normalizeContributor(contributor) {
+  return {
+    id: contributor?.id || contributor?.login,
+    login: contributor?.login || "unknown",
+    avatar_url: contributor?.avatar_url || "",
+    profile_url: contributor?.html_url || `https://github.com/${contributor?.login || ""}`,
+    contributions: Number(contributor?.contributions || 0),
+  };
+}
+
 function readBundledReleaseNotes() {
   try {
     if (!fs.existsSync(BUNDLED_RELEASE_NOTES_FILE)) {
@@ -114,6 +130,58 @@ function readBundledReleaseNotes() {
     console.warn(`Unable to read bundled release notes: ${error.message}`);
     return null;
   }
+}
+
+function readContributorsCache() {
+  try {
+    if (!fs.existsSync(CONTRIBUTORS_CACHE_FILE)) {
+      return null;
+    }
+
+    return JSON.parse(fs.readFileSync(CONTRIBUTORS_CACHE_FILE, "utf8"));
+  } catch (error) {
+    console.warn(`Unable to read GitHub contributors cache: ${error.message}`);
+    return null;
+  }
+}
+
+function writeContributorsCache(data) {
+  try {
+    fs.mkdirSync(path.dirname(CONTRIBUTORS_CACHE_FILE), { recursive: true });
+    fs.writeFileSync(
+      CONTRIBUTORS_CACHE_FILE,
+      JSON.stringify(
+        {
+          cached_at: new Date().toISOString(),
+          data,
+        },
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    console.warn(`Unable to write GitHub contributors cache: ${error.message}`);
+  }
+}
+
+function getCachedContributors({ allowStale = false } = {}) {
+  const cache = readContributorsCache();
+  if (!cache?.cached_at || !cache?.data?.contributors?.length) {
+    return null;
+  }
+
+  const age = Date.now() - new Date(cache.cached_at).getTime();
+  const maxAge = allowStale ? RELEASE_CACHE_MAX_STALE_MS : RELEASE_CACHE_TTL_MS;
+  if (!Number.isFinite(age) || age < 0 || age > maxAge) {
+    return null;
+  }
+
+  return {
+    ...cache.data,
+    cached: true,
+    cached_at: cache.cached_at,
+    stale: age > RELEASE_CACHE_TTL_MS,
+  };
 }
 
 function isPrereleaseVersion(version) {
@@ -293,6 +361,52 @@ async function fetchReleaseNotes() {
   }
 }
 
+async function fetchGithubContributors() {
+  const currentVersion = packageJson.version;
+  const cached = getCachedContributors();
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const response = await axios.get(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contributors`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": `JellyGlance/${currentVersion}`,
+        ...(process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
+      },
+      params: {
+        per_page: 100,
+        anon: "false",
+      },
+      timeout: 10000,
+    });
+
+    const data = {
+      repository_url: `https://github.com/${REPO_OWNER}/${REPO_NAME}`,
+      contributors: (response.data || [])
+        .filter((contributor) => !isBotContributor(contributor))
+        .map(normalizeContributor)
+        .filter((contributor) => contributor.login && contributor.login !== "unknown"),
+    };
+
+    if (data.contributors.length) {
+      writeContributorsCache(data);
+      return data;
+    }
+
+    throw new Error("GitHub returned no non-bot contributors");
+  } catch (error) {
+    const staleCache = getCachedContributors({ allowStale: true });
+    if (staleCache) {
+      console.warn(`Using cached GitHub contributors after fetch failed: ${error.message}`);
+      return staleCache;
+    }
+
+    throw error;
+  }
+}
+
 async function checkForUpdates() {
   const currentVersion = packageJson.version;
   let result = {
@@ -353,4 +467,5 @@ async function checkForUpdates() {
 module.exports = {
   checkForUpdates: memoizee(checkForUpdates, { maxAge: 300000, promise: true }),
   fetchReleaseNotes: memoizee(fetchReleaseNotes, { maxAge: 300000, promise: true }),
+  fetchGithubContributors: memoizee(fetchGithubContributors, { maxAge: 300000, promise: true }),
 };

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,10 +1,14 @@
 @import "pages/css/variables.css";
+:root {
+  --jg-sidebar-width: 250px;
+}
+
 .app-shell-main {
   flex: 1 1 auto;
   width: auto !important;
   min-width: 0;
   max-width: 100%;
-  min-height: 100vh;
+  min-height: 125vh;
   margin-inline: 0;
   padding: 16px;
   overflow: auto;
@@ -15,9 +19,11 @@
 
 .App > .d-flex {
   min-width: 0;
+  max-width: 100%;
+  overflow-x: clip;
 }
 
-.app-shell-main > :is(.about-page, .downloads-page, .integrations-page, .libraries, .repair-hub, .settings, .watch-stats, .user-profile-page, .Home) {
+.app-shell-main > :is(.about-page, .downloads-page, .integrations-page, .libraries, .repair-hub, .settings, .transcodes-page, .watch-stats, .user-profile-page, .Home) {
   width: 100%;
   min-width: 0;
   max-width: 100%;
@@ -30,13 +36,21 @@
   align-self: start;
 }
 
+@media (min-width: 901px) and (hover: hover) {
+  .app-shell-main {
+    width: calc(125vw - var(--jg-sidebar-width, 250px)) !important;
+    max-width: calc(125vw - var(--jg-sidebar-width, 250px));
+    overflow-x: hidden;
+  }
+}
+
 @media (max-width: 900px), (hover: none) and (pointer: coarse) {
   .App > .d-flex {
     flex-direction: column !important;
   }
 
   .app-shell-main {
-    min-height: 100vh;
+    min-height: 125vh;
     padding: 10px 10px calc(88px + env(safe-area-inset-bottom, 0px));
     overflow-x: hidden;
   }

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,6 +1,6 @@
 // import logo from './logo.svg';
 import "./App.css";
-import React, { useState, useEffect } from "react";
+import React, { lazy, useState, useEffect } from "react";
 import { Routes, Route } from "react-router-dom";
 import axios from "./lib/axios_instance";
 
@@ -16,17 +16,17 @@ import { DEFAULT_THEME, applyTheme } from "./lib/theme";
 import { getStoredNotificationSettings, normalizeNotificationSettings, storeNotificationSettings } from "./lib/notification-settings";
 
 import Loading from "./pages/components/general/loading";
-
-import Signup from "./pages/signup";
-import Setup from "./pages/setup";
-import FirstRunExtras from "./pages/first-run-extras";
-import Login from "./pages/login";
-
-import Navbar from "./pages/components/general/navbar";
 import ErrorPage from "./pages/components/general/error";
-import WhatsNewModal from "./pages/components/general/WhatsNewModal";
 import routes from "./routes";
 import { FIRST_RUN_EXTRAS_KEY } from "./lib/first-run";
+import { APP_VERSION_STORAGE_KEY } from "./lib/events";
+
+const Signup = lazy(() => import("./pages/signup"));
+const Setup = lazy(() => import("./pages/setup"));
+const FirstRunExtras = lazy(() => import("./pages/first-run-extras"));
+const Login = lazy(() => import("./pages/login"));
+const Navbar = lazy(() => import("./pages/components/general/navbar"));
+const WhatsNewModal = lazy(() => import("./pages/components/general/WhatsNewModal"));
 
 function notificationKind(message) {
   const type = String(message?.type || "").toLowerCase();
@@ -95,6 +95,7 @@ function App() {
   const [config, setConfig] = useState(null);
   const [loading, setLoading] = useState(true);
   const [errorFlag, seterrorFlag] = useState(false);
+  const [startupErrorMessage, setStartupErrorMessage] = useState("Error: Unable to connect to JellyGlance Backend");
   const [notificationSettings, setNotificationSettings] = useState(getStoredNotificationSettings);
   const token = localStorage.getItem("token");
   const shouldShowFirstRunExtras =
@@ -103,7 +104,7 @@ function App() {
     token !== null &&
     config?.settings?.firstRunExtrasCompleted !== true &&
     (localStorage.getItem(FIRST_RUN_EXTRAS_KEY) === "true" || config?.settings?.firstRunExtrasPending === true);
-  const kioskMode = window.location.pathname === "/home/kiosk";
+  const kioskMode = window.location.pathname === "/home/kiosk" || window.location.pathname === "/kiosk";
 
   const wsListeners = [
     { task: "PlaybackSyncTask", ref: React.useRef(null) },
@@ -234,10 +235,15 @@ function App() {
         .then(async (response) => {
           if (response.status === 200) {
             setSetupState(response.data.state);
+            if (response.data.version) {
+              localStorage.setItem(APP_VERSION_STORAGE_KEY, response.data.version);
+            }
           }
         })
         .catch((error) => {
           console.log(error);
+          const message = error.response?.data?.message || error.response?.data?.error || error.message;
+          setStartupErrorMessage(error.response?.status ? `Error ${error.response.status}: ${message}` : "Error: Unable to connect to JellyGlance Backend");
           seterrorFlag(true);
         });
     }
@@ -277,7 +283,7 @@ function App() {
   }
 
   if (errorFlag) {
-    return <ErrorPage message={"Error: Unable to connect to JellyGlance Backend"} />;
+    return <ErrorPage message={startupErrorMessage} />;
   }
 
   if (!config && setupState === 2 && (token === undefined || token === null)) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -14,6 +14,9 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: white;
+  width: 125%;
+  min-height: 125vh;
+  zoom: 0.8;
 }
 
 * {
@@ -44,6 +47,7 @@ code {
 
 body {
   overflow: auto;
+  overflow-x: hidden;
 }
 
 :root[data-font-weight="comfortable"] {

--- a/apps/web/src/lib/events.js
+++ b/apps/web/src/lib/events.js
@@ -1,0 +1,2 @@
+export const OPEN_WHATS_NEW_EVENT = "jellyglance-open-whats-new";
+export const APP_VERSION_STORAGE_KEY = "jellyglance_app_version";

--- a/apps/web/src/lib/home-settings.js
+++ b/apps/web/src/lib/home-settings.js
@@ -1,0 +1,255 @@
+export const HOME_SETTINGS_STORAGE_PREFIX = "jellyglance_home_settings";
+export const LEGACY_HOME_ORDER_STORAGE_KEY = "jellyglance_home_section_order";
+export const HOME_LAYOUT_VERSION = 3;
+
+const DEFAULT_HIDDEN_SECTION_IDS = ["seasonGaps", "tdarr", "wizarr", "bazarr", "prowlarr"];
+const INTEGRATION_WIDGET_SECTION_IDS = ["tdarr", "wizarr", "bazarr", "prowlarr"];
+
+export const HOME_SECTION_DEFINITIONS = [
+  { id: "sessions", label: "Active sessions" },
+  { id: "overview", label: "Overview" },
+  { id: "hall", label: "Hall of Fame" },
+  { id: "library", label: "Library health" },
+  { id: "catalog", label: "Catalog totals" },
+  { id: "milestones", label: "Milestones" },
+  { id: "week", label: "This week" },
+  { id: "attention", label: "Needs attention" },
+  { id: "trends", label: "Today vs last week" },
+  { id: "issues", label: "Library issues" },
+  { id: "watchParty", label: "Watch party" },
+  { id: "seasonGaps", label: "Season gaps" },
+  { id: "tdarr", label: "Tdarr transcodes" },
+  { id: "wizarr", label: "Wizarr invites" },
+  { id: "bazarr", label: "Bazarr subtitles" },
+  { id: "prowlarr", label: "Prowlarr indexers" },
+  { id: "automation", label: "Automation feed" },
+  { id: "quickActions", label: "Quick actions" },
+  { id: "operations", label: "Operations" },
+];
+
+export const DEFAULT_HOME_ORDER = HOME_SECTION_DEFINITIONS.map((section) => section.id);
+const KIOSK_DEFAULT_HIDDEN = DEFAULT_HOME_ORDER.filter((sectionId) => sectionId !== "sessions");
+export const CURATED_DEFAULT_HOME_ORDER = [
+  "sessions",
+  "attention",
+  "overview",
+  "operations",
+  "milestones",
+  "week",
+  "hall",
+  "trends",
+  "watchParty",
+  "quickActions",
+  "library",
+  "catalog",
+  "issues",
+  "seasonGaps",
+  "tdarr",
+  "wizarr",
+  "bazarr",
+  "prowlarr",
+  "automation",
+];
+
+export const DEFAULT_HOME_SETTINGS = {
+  order: CURATED_DEFAULT_HOME_ORDER,
+  hidden: DEFAULT_HIDDEN_SECTION_IDS,
+  pinned: "",
+  density: "comfortable",
+  autoRotate: false,
+  preset: "default",
+  title: "",
+  theme: "default",
+  alertRules: { backupDays: 7, requestThreshold: 1, missingPosterThreshold: 1 },
+  dismissedAlerts: {},
+  sizes: {
+    sessions: "large",
+    overview: "large",
+    hall: "large",
+    operations: "large",
+    catalog: "large",
+    library: "large",
+    milestones: "large",
+    week: "large",
+    tdarr: "small",
+    wizarr: "small",
+    bazarr: "small",
+    prowlarr: "small",
+  },
+  version: HOME_LAYOUT_VERSION,
+};
+
+export const HOME_PRESETS = {
+  default: {
+    label: "Default",
+    order: CURATED_DEFAULT_HOME_ORDER,
+    hidden: DEFAULT_HIDDEN_SECTION_IDS,
+    density: "comfortable",
+    sizes: {
+      sessions: "large",
+      overview: "large",
+      attention: "small",
+      quickActions: "small",
+    },
+  },
+  admin: {
+    label: "Admin",
+    order: ["attention", "operations", "quickActions", "automation", "tdarr", "bazarr", "prowlarr", "wizarr", "sessions", "overview", "milestones", "trends", "issues", "week", "hall", "library", "catalog", "seasonGaps", "watchParty"],
+    hidden: ["watchParty", ...INTEGRATION_WIDGET_SECTION_IDS],
+    density: "compact",
+    sizes: {
+      attention: "small",
+      operations: "large",
+      quickActions: "small",
+      automation: "small",
+      tdarr: "small",
+      bazarr: "small",
+      prowlarr: "small",
+      wizarr: "small",
+    },
+  },
+  family: {
+    label: "Family",
+    order: ["sessions", "watchParty", "week", "milestones", "hall", "overview", "trends", "catalog", "operations", "quickActions", "library", "attention", "issues", "seasonGaps", "automation", "tdarr", "wizarr", "bazarr", "prowlarr"],
+    hidden: ["issues", "seasonGaps", "automation", ...INTEGRATION_WIDGET_SECTION_IDS],
+    density: "comfortable",
+    sizes: {
+      sessions: "large",
+      watchParty: "large",
+      week: "medium",
+      hall: "large",
+    },
+  },
+  media: {
+    label: "Media Stats",
+    order: ["overview", "milestones", "trends", "catalog", "library", "issues", "seasonGaps", "week", "watchParty", "hall", "sessions", "operations", "quickActions", "attention", "automation", "tdarr", "wizarr", "bazarr", "prowlarr"],
+    hidden: ["automation", ...INTEGRATION_WIDGET_SECTION_IDS],
+    density: "comfortable",
+    sizes: {
+      overview: "large",
+      trends: "large",
+      catalog: "medium",
+      issues: "medium",
+    },
+  },
+  requests: {
+    label: "Requests First",
+    order: ["attention", "operations", "quickActions", "automation", "wizarr", "sessions", "week", "milestones", "overview", "hall", "trends", "library", "catalog", "issues", "seasonGaps", "watchParty", "tdarr", "bazarr", "prowlarr"],
+    hidden: DEFAULT_HIDDEN_SECTION_IDS,
+    density: "compact",
+    sizes: {
+      attention: "small",
+      operations: "large",
+      quickActions: "small",
+    },
+  },
+  kiosk: {
+    label: "Kiosk",
+    order: ["sessions", "overview", "hall", "week", "trends", "watchParty", "catalog", "library", "milestones", "operations", "attention", "issues", "seasonGaps", "tdarr", "wizarr", "bazarr", "prowlarr", "automation", "quickActions"],
+    hidden: KIOSK_DEFAULT_HIDDEN,
+    density: "comfortable",
+    sizes: {
+      sessions: "large",
+      overview: "large",
+      hall: "large",
+      week: "large",
+      trends: "large",
+    },
+  },
+};
+
+export const HOME_WIDGET_SIZE_LABELS = {
+  small: "Compact",
+  medium: "Half width",
+  large: "Full width",
+};
+
+export function normalizeHomeOrder(order) {
+  const knownSections = new Set(DEFAULT_HOME_ORDER);
+  const savedOrder = Array.isArray(order) ? order.filter((sectionId) => knownSections.has(sectionId)) : [];
+  const missingSections = DEFAULT_HOME_ORDER.filter((sectionId) => !savedOrder.includes(sectionId));
+  return [...savedOrder, ...missingSections];
+}
+
+export function getHomeTokenPayload() {
+  const token = localStorage.getItem("token");
+  if (!token) return null;
+  try {
+    return JSON.parse(window.atob(token.split(".")[1]?.replace(/-/g, "+").replace(/_/g, "/") || ""));
+  } catch {
+    return null;
+  }
+}
+
+export function getHomeSettingsStorageKey(scope = "user") {
+  if (scope === "kiosk") return `${HOME_SETTINGS_STORAGE_PREFIX}:kiosk`;
+  const payload = getHomeTokenPayload();
+  if (!payload) return `${HOME_SETTINGS_STORAGE_PREFIX}:browser`;
+  return `${HOME_SETTINGS_STORAGE_PREFIX}:${payload.sub || payload.userid || payload.username || payload.name || "user"}`;
+}
+
+export function normalizeHomeSettings(settings) {
+  const normalized = { ...DEFAULT_HOME_SETTINGS, ...(settings || {}) };
+  const knownSections = new Set(DEFAULT_HOME_ORDER);
+  normalized.order = normalizeHomeOrder(normalized.order);
+  normalized.hidden = Array.isArray(normalized.hidden) ? [...new Set(normalized.hidden.filter((sectionId) => knownSections.has(sectionId)))] : [];
+  if (Number(normalized.version || 0) < HOME_LAYOUT_VERSION) {
+    normalized.hidden = [...new Set([...normalized.hidden, ...DEFAULT_HIDDEN_SECTION_IDS])];
+  }
+  normalized.pinned = knownSections.has(normalized.pinned) ? normalized.pinned : "";
+  normalized.density = normalized.density === "compact" ? "compact" : "comfortable";
+  normalized.autoRotate = Boolean(normalized.autoRotate);
+  normalized.preset = normalized.preset || "custom";
+  normalized.title = typeof normalized.title === "string" ? normalized.title : "";
+  normalized.theme = ["default", "darker", "neon", "highContrast", "wall"].includes(normalized.theme) ? normalized.theme : "default";
+  normalized.alertRules = {
+    ...DEFAULT_HOME_SETTINGS.alertRules,
+    ...(normalized.alertRules || {}),
+  };
+  normalized.dismissedAlerts = normalized.dismissedAlerts && typeof normalized.dismissedAlerts === "object" ? normalized.dismissedAlerts : {};
+  normalized.sizes = normalized.sizes && typeof normalized.sizes === "object" ? { ...DEFAULT_HOME_SETTINGS.sizes, ...normalized.sizes } : DEFAULT_HOME_SETTINGS.sizes;
+  normalized.version = Number(normalized.version || 0);
+  return normalized;
+}
+
+export function getRoleDefaultHomeSettings() {
+  const payload = getHomeTokenPayload();
+  const role = String(payload?.role || payload?.Role || payload?.roles?.[0] || "").toLowerCase();
+  if (role.includes("admin") || role.includes("owner") || role.includes("manager")) {
+    return normalizeHomeSettings({ ...DEFAULT_HOME_SETTINGS, ...HOME_PRESETS.admin, sizes: HOME_PRESETS.admin.sizes, preset: "admin" });
+  }
+  return normalizeHomeSettings({ ...DEFAULT_HOME_SETTINGS, ...HOME_PRESETS.family, sizes: HOME_PRESETS.family.sizes, preset: "family" });
+}
+
+export function loadHomeSettings(scope = "user") {
+  const storageKey = getHomeSettingsStorageKey(scope);
+  try {
+    const saved = localStorage.getItem(storageKey);
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      const normalized = normalizeHomeSettings(parsed);
+      if (scope === "kiosk" && normalized.preset === "kiosk") {
+        return normalizeHomeSettings({ ...DEFAULT_HOME_SETTINGS, ...HOME_PRESETS.kiosk, sizes: HOME_PRESETS.kiosk.sizes, preset: "kiosk", autoRotate: false, title: normalized.title || "JellyGlance Kiosk", theme: normalized.theme });
+      }
+      const stillOldDefault = normalized.version < HOME_LAYOUT_VERSION && (!parsed.preset || parsed.preset === "custom") && JSON.stringify(normalizeHomeOrder(parsed.order)) === JSON.stringify(DEFAULT_HOME_ORDER);
+      return stillOldDefault ? normalizeHomeSettings(DEFAULT_HOME_SETTINGS) : normalized;
+    }
+
+    if (scope !== "kiosk") {
+      const legacyOrder = localStorage.getItem(LEGACY_HOME_ORDER_STORAGE_KEY);
+      if (legacyOrder) return normalizeHomeSettings({ order: JSON.parse(legacyOrder) });
+      return getRoleDefaultHomeSettings();
+    }
+  } catch {
+    return normalizeHomeSettings(DEFAULT_HOME_SETTINGS);
+  }
+
+  return normalizeHomeSettings({ ...DEFAULT_HOME_SETTINGS, ...HOME_PRESETS.kiosk, sizes: HOME_PRESETS.kiosk.sizes, preset: "kiosk", autoRotate: false, title: "JellyGlance Kiosk" });
+}
+
+export function saveHomeSettings(settings, scope = "user") {
+  const normalized = normalizeHomeSettings(settings);
+  localStorage.setItem(getHomeSettingsStorageKey(scope), JSON.stringify(normalized));
+  window.dispatchEvent(new CustomEvent("jellyglance-home-settings-updated", { detail: { scope, settings: normalized } }));
+  return normalized;
+}

--- a/apps/web/src/lib/nav-order.js
+++ b/apps/web/src/lib/nav-order.js
@@ -1,0 +1,72 @@
+export const NAV_ORDER_STORAGE_KEY = "jellyglance_nav_order";
+export const NAV_HIDDEN_STORAGE_KEY = "jellyglance_nav_hidden";
+export const LOCKED_NAV_LINKS = new Set(["", "settings", "about"]);
+
+export function getDefaultReorderableNavLinks(navItems = []) {
+  return navItems.filter((item) => !LOCKED_NAV_LINKS.has(item.link)).map((item) => item.link);
+}
+
+export function getStoredNavOrder(navItems = []) {
+  const defaultOrder = getDefaultReorderableNavLinks(navItems);
+
+  try {
+    const parsed = JSON.parse(localStorage.getItem(NAV_ORDER_STORAGE_KEY) || "[]");
+    const savedOrder = Array.isArray(parsed) ? parsed.filter((link) => defaultOrder.includes(link)) : [];
+    return [...savedOrder, ...defaultOrder.filter((link) => !savedOrder.includes(link))];
+  } catch {
+    return defaultOrder;
+  }
+}
+
+export function saveNavOrder(order = [], navItems = []) {
+  const defaultOrder = getDefaultReorderableNavLinks(navItems);
+  const nextOrder = [...order.filter((link) => defaultOrder.includes(link)), ...defaultOrder.filter((link) => !order.includes(link))];
+  localStorage.setItem(NAV_ORDER_STORAGE_KEY, JSON.stringify(nextOrder));
+  window.dispatchEvent(new CustomEvent("jellyglance-nav-order-updated", { detail: nextOrder }));
+  return nextOrder;
+}
+
+export function resetNavOrder() {
+  localStorage.removeItem(NAV_ORDER_STORAGE_KEY);
+  window.dispatchEvent(new CustomEvent("jellyglance-nav-order-updated"));
+}
+
+export function getStoredHiddenNavLinks(navItems = []) {
+  const hideableLinks = new Set(navItems.filter((item) => !LOCKED_NAV_LINKS.has(item.link)).map((item) => item.link));
+
+  try {
+    const parsed = JSON.parse(localStorage.getItem(NAV_HIDDEN_STORAGE_KEY) || "[]");
+    return Array.isArray(parsed) ? parsed.filter((link) => hideableLinks.has(link)) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveHiddenNavLinks(hiddenLinks = [], navItems = []) {
+  const hideableLinks = new Set(navItems.filter((item) => !LOCKED_NAV_LINKS.has(item.link)).map((item) => item.link));
+  const nextHiddenLinks = [...new Set(hiddenLinks.filter((link) => hideableLinks.has(link)))];
+  localStorage.setItem(NAV_HIDDEN_STORAGE_KEY, JSON.stringify(nextHiddenLinks));
+  window.dispatchEvent(new CustomEvent("jellyglance-nav-visibility-updated", { detail: nextHiddenLinks }));
+  return nextHiddenLinks;
+}
+
+export function resetHiddenNavLinks() {
+  localStorage.removeItem(NAV_HIDDEN_STORAGE_KEY);
+  window.dispatchEvent(new CustomEvent("jellyglance-nav-visibility-updated", { detail: [] }));
+}
+
+export function applyNavOrder(navItems = [], order = getStoredNavOrder(navItems)) {
+  const orderMap = new Map(order.map((link, index) => [link, index]));
+  const homeItems = navItems.filter((item) => item.link === "");
+  const settingsItems = navItems.filter((item) => item.link === "settings");
+  const aboutItems = navItems.filter((item) => item.link === "about");
+  const middleItems = navItems
+    .filter((item) => !LOCKED_NAV_LINKS.has(item.link))
+    .sort((first, second) => {
+      const firstOrder = orderMap.has(first.link) ? orderMap.get(first.link) : Number.MAX_SAFE_INTEGER;
+      const secondOrder = orderMap.has(second.link) ? orderMap.get(second.link) : Number.MAX_SAFE_INTEGER;
+      return firstOrder - secondOrder || first.id - second.id;
+    });
+
+  return [...homeItems, ...middleItems, ...settingsItems, ...aboutItems];
+}

--- a/apps/web/src/lib/navdata.jsx
+++ b/apps/web/src/lib/navdata.jsx
@@ -13,6 +13,8 @@ import ChatCheckFillIcon from 'remixicon-react/ChatCheckFillIcon';
 import DownloadCloud2FillIcon from 'remixicon-react/DownloadCloud2FillIcon';
 import ServerFillIcon from 'remixicon-react/ServerFillIcon';
 import UserAddFillIcon from 'remixicon-react/UserAddFillIcon';
+import CpuFillIcon from 'remixicon-react/CpuFillIcon';
+import RadarFillIcon from 'remixicon-react/RadarFillIcon';
 import { Trans } from 'react-i18next';
 
 
@@ -21,81 +23,108 @@ export const navData = [
         id: 0,
         icon: <HomeFillIcon/>,
         text: <Trans i18nKey="MENU_TABS.HOME" />,
+        label: "Home",
         link: ""
     },
     {
         id: 1,
         icon: <Movie2FillIcon />,
         text: "Recently Added",
+        label: "Recently Added",
         link: "recently-added"
     },
     {
         id: 2,
         icon: <GalleryFillIcon />,
         text: <Trans i18nKey="MENU_TABS.LIBRARIES" />,
+        label: "Libraries",
         link: "libraries"
     },
     {
         id: 3,
         icon: <UserFillIcon />,
         text: <Trans i18nKey="MENU_TABS.USERS" />,
+        label: "Users",
         link: "users"
     },
     {
         id: 4,
         icon: <HistoryFillIcon />,
         text: <Trans i18nKey="MENU_TABS.ACTIVITY" />,
+        label: "Activity",
         link: "activity"
     },
     {
         id: 5,
         icon: <CalendarEventFillIcon />,
         text: "Calendar",
+        label: "Calendar",
         link: "calendar"
     },
     {
         id: 6,
         icon: <ChatCheckFillIcon />,
         text: "Requests",
+        label: "Requests",
         link: "requests"
     },
     {
         id: 7,
         icon: <DownloadCloud2FillIcon />,
         text: "Downloads",
+        label: "Downloads",
         link: "downloads"
     },
     {
         id: 8,
-        icon: <UserAddFillIcon />,
-        text: "Invites",
-        link: "wizarr"
+        icon: <CpuFillIcon />,
+        text: "Active Transcodes",
+        label: "Active Transcodes",
+        link: "active-transcodes"
     },
     {
         id: 9,
+        icon: <UserAddFillIcon />,
+        text: "Invites",
+        label: "Invites",
+        link: "wizarr"
+    },
+    {
+        id: 10,
+        icon: <RadarFillIcon />,
+        text: "Automation Health",
+        label: "Automation Health",
+        link: "automation-health"
+    },
+    {
+        id: 11,
         icon: <BarChartFillIcon />,
         text: <Trans i18nKey="MENU_TABS.STATISTICS" />,
+        label: "Statistics",
         link: "statistics"
     },
 
     {
-        id: 10,
+        id: 12,
         icon: <ServerFillIcon />,
         text: <Trans i18nKey="MENU_TABS.JELLYFIN_JOBS" />,
+        label: "Jellyfin Jobs",
         link: "server-management"
     },
     {
-        id: 11,
+        id: 13,
         icon: <SettingsFillIcon />,
         text: <Trans i18nKey="MENU_TABS.SETTINGS" />,
+        label: "Settings",
         link: "settings"
     }
     ,
 
     {
-        id: 12,
+        id: 14,
         icon: <InformationFillIcon />,
         text: <Trans i18nKey="MENU_TABS.ABOUT" />,
+        label: "About",
         link: "about"
     }
 

--- a/apps/web/src/lib/platform-icons.jsx
+++ b/apps/web/src/lib/platform-icons.jsx
@@ -9,6 +9,7 @@ import {
   siGooglecast,
   siGooglechrome,
   siGoogletv,
+  siHomeassistant,
   siJellyfin,
   siKodi,
   siLg,
@@ -23,9 +24,19 @@ import {
   siVivaldi,
 } from "simple-icons";
 
+const selfHostedIconUrl = (slug) => `https://cdn.jsdelivr.net/gh/selfhst/icons/svg/${slug}.svg`;
+
 const iconMap = [
+  { match: ["home assistant", "hacs"], icon: siHomeassistant },
+  { match: ["reclaimerr"], imageSlug: "reclaimerr", title: "Reclaimerr" },
+  { match: ["jellystat"], imageSlug: "jellystat", title: "Jellystat" },
+  { match: ["jellyseerr"], imageSlug: "jellyseerr", title: "Jellyseerr" },
+  { match: ["overseerr"], imageSlug: "overseerr", title: "Overseerr" },
+  { match: ["seerr"], imageSlug: "seerr", title: "Seerr" },
+  { match: ["jellyfin-uwp", "xbox"], imageSlug: "xbox", title: "Xbox" },
   { match: ["roku"], icon: siRoku },
   { match: ["android", "fire tv"], icon: siAndroid },
+  { match: ["edge chromium", "microsoft edge"], imageSlug: "microsoft-edge", title: "Microsoft Edge" },
   { match: ["apple tv", "tvos"], icon: siAppletv },
   { match: ["iphone", "ipad", "ios", "macos", "apple"], icon: siApple },
   { match: ["google tv"], icon: siGoogletv },
@@ -67,7 +78,12 @@ function ChromeIcon({ className = "" }) {
 }
 
 export function PlatformIcon({ client, deviceName, className = "" }) {
-  const { icon, color: overrideColor } = getPlatformIconMeta(client, deviceName);
+  const { icon, imageSlug, title, color: overrideColor } = getPlatformIconMeta(client, deviceName);
+
+  if (imageSlug) {
+    return <img className={className} src={selfHostedIconUrl(imageSlug)} alt="" loading="lazy" decoding="async" title={title} />;
+  }
+
   const color = overrideColor || `#${icon.hex}`;
 
   if (icon === siGooglechrome) {

--- a/apps/web/src/lib/privacy-settings.js
+++ b/apps/web/src/lib/privacy-settings.js
@@ -1,0 +1,48 @@
+export const ACTIVE_SESSION_IP_PRIVACY_KEY = "jellyglance_active_session_ip_privacy";
+export const ACTIVE_SESSION_IP_PRIVACY_EVENT = "jellyglance-active-session-ip-privacy-updated";
+
+export const ACTIVE_SESSION_IP_PRIVACY_OPTIONS = [
+  {
+    id: "none",
+    title: "None",
+    text: "Display session IP addresses on Home and Kiosk.",
+  },
+  {
+    id: "home",
+    title: "Hide on Home",
+    text: "Hide session IP addresses on the Home dashboard only.",
+  },
+  {
+    id: "kiosk",
+    title: "Hide on Kiosk",
+    text: "Hide session IP addresses on the Kiosk display only.",
+  },
+  {
+    id: "both",
+    title: "Hide on both",
+    text: "Hide session IP addresses on Home and Kiosk.",
+  },
+];
+
+const VALID_ACTIVE_SESSION_IP_PRIVACY = new Set(ACTIVE_SESSION_IP_PRIVACY_OPTIONS.map((option) => option.id));
+
+export function getActiveSessionIpPrivacy() {
+  try {
+    const saved = localStorage.getItem(ACTIVE_SESSION_IP_PRIVACY_KEY) || "none";
+    return VALID_ACTIVE_SESSION_IP_PRIVACY.has(saved) ? saved : "none";
+  } catch {
+    return "none";
+  }
+}
+
+export function setActiveSessionIpPrivacy(value) {
+  const nextValue = VALID_ACTIVE_SESSION_IP_PRIVACY.has(value) ? value : "none";
+  localStorage.setItem(ACTIVE_SESSION_IP_PRIVACY_KEY, nextValue);
+  window.dispatchEvent(new CustomEvent(ACTIVE_SESSION_IP_PRIVACY_EVENT, { detail: nextValue }));
+  return nextValue;
+}
+
+export function shouldHideActiveSessionIp(surface, value = getActiveSessionIpPrivacy()) {
+  if (value === "both") return true;
+  return value === surface;
+}

--- a/apps/web/src/pages/about.jsx
+++ b/apps/web/src/pages/about.jsx
@@ -6,14 +6,19 @@ import ArchiveLineIcon from "remixicon-react/ArchiveLineIcon";
 import ArrowDownSLineIcon from "remixicon-react/ArrowDownSLineIcon";
 import CheckLineIcon from "remixicon-react/CheckLineIcon";
 import Database2LineIcon from "remixicon-react/Database2LineIcon";
+import DownloadCloud2LineIcon from "remixicon-react/DownloadCloud2LineIcon";
 import FilmLineIcon from "remixicon-react/FilmLineIcon";
 import GitBranchLineIcon from "remixicon-react/GitBranchLineIcon";
 import GithubFillIcon from "remixicon-react/GithubFillIcon";
 import HeartPulseLineIcon from "remixicon-react/HeartPulseLineIcon";
+import LayoutGridLineIcon from "remixicon-react/LayoutGridLineIcon";
 import PulseLineIcon from "remixicon-react/PulseLineIcon";
 import PriceTag3LineIcon from "remixicon-react/PriceTag3LineIcon";
+import RadarLineIcon from "remixicon-react/RadarLineIcon";
+import Settings3LineIcon from "remixicon-react/Settings3LineIcon";
 import ShieldCheckLineIcon from "remixicon-react/ShieldCheckLineIcon";
 import TaskLineIcon from "remixicon-react/TaskLineIcon";
+import TimerFlashLineIcon from "remixicon-react/TimerFlashLineIcon";
 
 function stripMarkdown(value) {
   return String(value || "")
@@ -65,6 +70,20 @@ function parseReleaseBody(body) {
   return sections.length ? sections : [{ title: "Notes", items: ["No release notes were provided for this version."] }];
 }
 
+function isBotContributor(contributor) {
+  const login = String(contributor?.login || "").toLowerCase();
+  return /\bbot\b/.test(login) || login.includes("[bot]") || login.includes("dependabot") || login.includes("github-actions");
+}
+
+const PROJECT_OWNER_LOGIN = "Nerdy-Technician";
+const PROJECT_OWNER_FALLBACK = {
+  id: "project-owner",
+  login: PROJECT_OWNER_LOGIN,
+  avatar_url: `https://github.com/${PROJECT_OWNER_LOGIN}.png?size=160`,
+  profile_url: `https://github.com/${PROJECT_OWNER_LOGIN}`,
+  contributions: 0,
+};
+
 export default function SettingsAbout() {
   const token = localStorage.getItem("token");
   const [data, setData] = useState({
@@ -76,9 +95,13 @@ export default function SettingsAbout() {
   const [releaseMessage, setReleaseMessage] = useState("Loading release notes...");
   const [selectedReleaseId, setSelectedReleaseId] = useState("");
   const [releaseMenuOpen, setReleaseMenuOpen] = useState(false);
+  const [contributors, setContributors] = useState([]);
+  const [contributorsMessage, setContributorsMessage] = useState("Loading GitHub profiles...");
   const updateMessage = data.message === "JellyGlance is up to date" ? "Up to date" : data.message;
   const selectedRelease = releaseData.releases.find((release) => String(release.id) === selectedReleaseId) || releaseData.releases[0];
   const selectedReleaseSections = parseReleaseBody(selectedRelease?.body);
+  const projectOwner = contributors.find((contributor) => contributor.login?.toLowerCase() === PROJECT_OWNER_LOGIN.toLowerCase()) || PROJECT_OWNER_FALLBACK;
+  const projectContributors = contributors.filter((contributor) => contributor.login?.toLowerCase() !== PROJECT_OWNER_LOGIN.toLowerCase());
 
   useEffect(() => {
     const fetchVersion = () => {
@@ -135,12 +158,33 @@ export default function SettingsAbout() {
       });
   }, [token]);
 
+  useEffect(() => {
+    if (!token) return;
+
+    axios
+      .get("/api/github/contributors", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        const profiles = (response.data?.contributors || []).filter((contributor) => !isBotContributor(contributor));
+        setContributors(profiles);
+        setContributorsMessage(profiles.length ? "" : "No GitHub profiles found.");
+      })
+      .catch((error) => {
+        console.log(error);
+        setContributorsMessage("Unable to load GitHub profiles.");
+      });
+  }, [token]);
+
   return (
     <div className="about-page">
       <header className="about-header">
         <p>About</p>
         <h1>JellyGlance</h1>
-        <span>Local Jellyfin visibility for sessions, activity, libraries, requests, downloads, and scheduled jobs.</span>
+        <span>Local Jellyfin visibility for sessions, libraries, requests, downloads, transcodes, automation health, and scheduled jobs.</span>
       </header>
 
       <main className="about-layout">
@@ -151,29 +195,59 @@ export default function SettingsAbout() {
               <p>
                 JellyGlance is a self-hosted dashboard for people running Jellyfin. It pulls the common admin checks into
                 one interface: current playback, recent library changes, watch history, health signals, integrations, and
-                background tasks.
+                background tasks, with customisable navigation and Home widgets for each browser.
               </p>
 
               <div className="about-feature-grid" aria-label="JellyGlance capabilities">
                 <article>
                   <PulseLineIcon />
                   <strong>Live status</strong>
-                  <span>See active streams, playback method, device, client, bitrate, transcoding state, and session history.</span>
+                  <span>See active streams, playback method, viewer, client, internal or remote IP, bitrate, transcode progress, and session history.</span>
                 </article>
                 <article>
                   <FilmLineIcon />
                   <strong>Library visibility</strong>
-                  <span>Track recent additions, library totals, missing artwork, item details, user activity, and watch trends.</span>
+                  <span>Track recent additions, library totals, missing artwork, item details, user activity, watch trends, and media quality signals.</span>
                 </article>
                 <article>
                   <TaskLineIcon />
                   <strong>Operations</strong>
-                  <span>Run syncs, backups, imports, health checks, notification tests, and background maintenance tasks.</span>
+                  <span>Run syncs, backups, imports, health checks, notification tests, repairs, logs, and background maintenance tasks.</span>
                 </article>
                 <article>
                   <Database2LineIcon />
                   <strong>Integrations</strong>
-                  <span>Connect request managers, download clients, Arr apps, Tautulli, Jellystat, webhooks, and newsletter tools.</span>
+                  <span>Connect Seerr, download clients, Sonarr/Radarr/Lidarr, Tdarr, Bazarr, Prowlarr, Tautulli, Jellystat, webhooks, and newsletters.</span>
+                </article>
+                <article>
+                  <TaskLineIcon />
+                  <strong>Requests</strong>
+                  <span>Review pending approvals, per-user queues, availability, issue reports, request trends, and Seerr search results.</span>
+                </article>
+                <article>
+                  <DownloadCloud2LineIcon />
+                  <strong>Downloads</strong>
+                  <span>Monitor torrent and usenet clients with queue state, progress, speeds, ETA, stalled items, and failed jobs.</span>
+                </article>
+                <article>
+                  <TimerFlashLineIcon />
+                  <strong>Active transcodes</strong>
+                  <span>Track Tdarr processing, queued items, history, thumbnails, source-to-target conversion, savings, and live percentages.</span>
+                </article>
+                <article>
+                  <RadarLineIcon />
+                  <strong>Automation health</strong>
+                  <span>Check Bazarr subtitle gaps, subtitle grabs, Prowlarr indexer health, failed indexers, and connected app sync status.</span>
+                </article>
+                <article>
+                  <LayoutGridLineIcon />
+                  <strong>Custom layouts</strong>
+                  <span>Collapse the sidebar, reorder navigation, hide tabs, resize Home widgets, and save browser-specific dashboard layouts.</span>
+                </article>
+                <article>
+                  <Settings3LineIcon />
+                  <strong>Admin tools</strong>
+                  <span>Manage settings, devices, integrations, API keys, webhooks, backups, imports, repair tasks, and application logs.</span>
                 </article>
               </div>
 
@@ -182,7 +256,8 @@ export default function SettingsAbout() {
                 <p>
                   JellyGlance runs beside your Jellyfin server and talks to the configured APIs with your saved settings. The
                   dashboard keeps local cache and task history so pages can show useful operational context without making
-                  every view feel like a raw API browser.
+                  every view feel like a raw API browser. Optional GitHub data powers release notes and project profile cards
+                  on this page.
                 </p>
               </section>
 
@@ -190,10 +265,40 @@ export default function SettingsAbout() {
                 <h2>What to configure</h2>
                 <ul>
                   <li>Jellyfin connection and authentication mode for the main dashboard.</li>
-                  <li>Optional Jellyseerr or Overseerr instances for request management.</li>
-                  <li>Optional qBittorrent, Transmission, Deluge, SABnzbd, NZBGet, or similar clients for downloads.</li>
-                  <li>Optional backups, webhooks, newsletter delivery, imports, and health monitoring.</li>
+                  <li>Optional Jellyseerr or Overseerr instances for request management, approvals, user queues, issue reports, and request trends.</li>
+                  <li>Optional qBittorrent, Transmission, Deluge, SABnzbd, NZBGet, or similar clients for download monitoring.</li>
+                  <li>Optional Tdarr for active transcodes, queue, history, conversion detail, thumbnails, and live progress.</li>
+                  <li>Optional Bazarr and Prowlarr for subtitle gaps, subtitle history, indexer health, failed indexers, and app sync status.</li>
+                  <li>Optional backups, webhooks, newsletter delivery, imports, health monitoring, custom navbar order, hidden tabs, and Home widgets.</li>
                 </ul>
+              </section>
+
+              <section className="about-contributors">
+                <div className="about-profile-group">
+                  <h3>Project Owner</h3>
+                  <a className="about-owner-card" href={projectOwner.profile_url} target="_blank" rel="noreferrer">
+                    <img src={projectOwner.avatar_url} alt="" loading="lazy" />
+                    <span>
+                      <strong>{projectOwner.login}</strong>
+                      <small>{projectOwner.contributions ? `${projectOwner.contributions} contribution${projectOwner.contributions === 1 ? "" : "s"}` : "Project owner"}</small>
+                    </span>
+                  </a>
+                </div>
+                <div className="about-profile-group">
+                  <h3>Contributors</h3>
+                  {contributorsMessage ? <p>{contributorsMessage}</p> : null}
+                  <div className="about-contributor-list">
+                    {projectContributors.map((contributor) => (
+                      <a key={contributor.id || contributor.login} href={contributor.profile_url} target="_blank" rel="noreferrer">
+                        <img src={contributor.avatar_url} alt="" loading="lazy" />
+                        <span>
+                          <strong>{contributor.login}</strong>
+                          <small>{contributor.contributions} contribution{contributor.contributions === 1 ? "" : "s"}</small>
+                        </span>
+                      </a>
+                    ))}
+                  </div>
+                </div>
               </section>
             </div>
 

--- a/apps/web/src/pages/active-transcodes.jsx
+++ b/apps/web/src/pages/active-transcodes.jsx
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import ArrowRightLineIcon from "remixicon-react/ArrowRightLineIcon";
+import CpuLineIcon from "remixicon-react/CpuLineIcon";
+import HistoryLineIcon from "remixicon-react/HistoryLineIcon";
+import ListCheck2Icon from "remixicon-react/ListCheck2Icon";
+import RefreshLineIcon from "remixicon-react/RefreshLineIcon";
+import axios from "../lib/axios_instance";
+import "./css/active-transcodes.css";
+
+const tabs = [
+  { key: "active", label: "Active", Icon: CpuLineIcon },
+  { key: "queued", label: "Queued", Icon: ListCheck2Icon },
+  { key: "history", label: "History", Icon: HistoryLineIcon },
+];
+const TRANSCODES_CACHE_KEY = "jellyglance_tdarr_transcodes_cache_v2";
+const TRANSCODES_CACHE_MAX_AGE_MS = 2 * 60 * 1000;
+const emptyBundle = { active: [], queued: [], history: [], stats: {} };
+
+function readTranscodesCache() {
+  try {
+    const cached = JSON.parse(localStorage.getItem(TRANSCODES_CACHE_KEY) || "null");
+    if (!cached?.data || Date.now() - Number(cached.cachedAt || 0) > TRANSCODES_CACHE_MAX_AGE_MS) return null;
+    return cached;
+  } catch {
+    return null;
+  }
+}
+
+function saveTranscodesCache(data) {
+  try {
+    localStorage.setItem(TRANSCODES_CACHE_KEY, JSON.stringify({ cachedAt: Date.now(), data }));
+  } catch {
+    // Rendering fresh data matters more than persisting this small cache.
+  }
+}
+
+function formatDate(value) {
+  if (!value) return "Unknown";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function formatBytes(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) return value || "";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const index = Math.min(Math.floor(Math.log(number) / Math.log(1024)), units.length - 1);
+  return `${(number / 1024 ** index).toFixed(index ? 1 : 0)} ${units[index]}`;
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat("en-GB").format(Number(value || 0));
+}
+
+function formatSaved(job) {
+  const saved = formatBytes(job.savedBytes);
+  if (!saved) return "";
+  return job.savedPercent ? `${saved} saved (${job.savedPercent}%)` : `${saved} saved`;
+}
+
+function JobCard({ job, kind }) {
+  const bannerStyle = job.bannerUrl
+    ? {
+        backgroundImage: `linear-gradient(90deg, rgba(7, 10, 16, 0.96), rgba(7, 10, 16, 0.72), rgba(7, 10, 16, 0.32)), url(${job.bannerUrl})`,
+      }
+    : {};
+  const progress = Number(job.progress || 0);
+  const showProgress = kind === "active";
+  const progressLabel = progress > 0 ? `${Math.round(progress)}% complete` : "In progress";
+  const historySizes = [formatBytes(job.sizeBefore), formatBytes(job.sizeAfter)].filter(Boolean);
+  const savedLabel = formatSaved(job);
+
+  return (
+    <article className={`transcode-job-card is-${kind}`} style={bannerStyle}>
+      <div className="transcode-job-thumbnail">
+        {job.thumbnailUrl ? <img src={job.thumbnailUrl} alt="" loading="lazy" decoding="async" /> : <span>{job.title.slice(0, 2)}</span>}
+      </div>
+      <div className="transcode-job-main">
+        <span className="transcode-job-kicker">{job.library || job.worker || "Tdarr"}</span>
+        <h2>{job.title}</h2>
+        <div className="transcode-route">
+          <strong>{job.from || "Source"}</strong>
+          {job.to ? (
+            <>
+              <ArrowRightLineIcon size={18} />
+              <strong>{job.to}</strong>
+            </>
+          ) : null}
+        </div>
+      </div>
+      <div className="transcode-job-meta">
+        <span>{job.worker || "Worker pending"}</span>
+        <span>{job.status || kind}</span>
+        {kind !== "history" && (job.sizeBefore || job.sizeAfter) ? <span>{[formatBytes(job.sizeBefore), formatBytes(job.sizeAfter)].filter(Boolean).join(" -> ")}</span> : null}
+        {kind !== "active" ? <span>{formatDate(job.updatedAt)}</span> : null}
+      </div>
+      {kind === "history" && (historySizes.length || savedLabel) ? (
+        <div className="transcode-history-details">
+          {historySizes.length ? (
+            <span>
+              <b>Size</b>
+              {historySizes.join(" -> ")}
+            </span>
+          ) : null}
+          {savedLabel ? (
+            <span>
+              <b>Saved</b>
+              {savedLabel}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+      {showProgress ? (
+        <div className={`transcode-progress${progress > 0 ? "" : " is-indeterminate"}`} aria-label={progressLabel}>
+          <span style={progress > 0 ? { width: `${progress}%` } : undefined} />
+          <em>{progressLabel}</em>
+        </div>
+      ) : null}
+      {job.reason ? <p className="transcode-reason">{job.reason}</p> : null}
+    </article>
+  );
+}
+
+export default function ActiveTranscodes() {
+  const cachedTranscodes = useMemo(() => readTranscodesCache(), []);
+  const [activeTab, setActiveTab] = useState("active");
+  const [bundle, setBundle] = useState(() => cachedTranscodes?.data || emptyBundle);
+  const [loading, setLoading] = useState(() => !cachedTranscodes);
+  const [error, setError] = useState("");
+  const [lastUpdated, setLastUpdated] = useState(() => cachedTranscodes?.cachedAt || null);
+
+  const jobs = useMemo(() => bundle[activeTab] || [], [activeTab, bundle]);
+  const activeCount = Number(bundle.stats?.active || bundle.active?.length || 0);
+  const queueCount = Number(bundle.stats?.queue ?? bundle.stats?.queued ?? bundle.queued?.length ?? 0);
+  const processedCount = Number(bundle.stats?.processed || 0);
+  const erroredCount = Number(bundle.stats?.errored || 0);
+  const savedSize = formatBytes(bundle.stats?.saved || 0);
+
+  const loadTranscodes = useCallback(async ({ silent = false, force = false } = {}) => {
+    try {
+      if (!silent) setLoading(true);
+      setError("");
+      const response = await axios.get("/api/tdarr/transcodes", { params: force ? { force: "true" } : undefined });
+      const nextBundle = response.data || emptyBundle;
+      setBundle(nextBundle);
+      saveTranscodesCache(nextBundle);
+      setLastUpdated(Date.now());
+      const nextActiveCount = Number(nextBundle.stats?.active || nextBundle.active?.length || 0);
+      const nextQueueCount = Number(nextBundle.stats?.queue ?? nextBundle.stats?.queued ?? nextBundle.queued?.length ?? 0);
+      localStorage.setItem("jellyglance_active_transcode_count", String(nextActiveCount));
+      window.dispatchEvent(new CustomEvent("jellyglance-transcode-count", { detail: nextActiveCount }));
+      return { active: nextActiveCount, queued: nextQueueCount };
+    } catch (requestError) {
+      setError(requestError?.response?.data?.error || "Unable to load Tdarr transcodes.");
+      return { active: 0, queued: 0 };
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let stopped = false;
+    let timeoutId;
+
+    async function poll(silent = false) {
+      const counts = await loadTranscodes({ silent });
+      if (stopped) return;
+      const delay = counts.active > 0 ? 5000 : counts.queued > 0 ? 15000 : 60000;
+      timeoutId = window.setTimeout(() => poll(true), delay);
+    }
+
+    poll(Boolean(cachedTranscodes));
+    return () => {
+      stopped = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [cachedTranscodes, loadTranscodes]);
+
+  return (
+    <div className="transcodes-page">
+      <header className="transcodes-header">
+        <div>
+          <p>Active Transcodes</p>
+          <h1>Tdarr</h1>
+          <span>{lastUpdated ? `Last updated ${new Intl.DateTimeFormat("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" }).format(new Date(lastUpdated))}` : "Monitor active workers, queued files, and finished transcode history."}</span>
+        </div>
+        <button type="button" onClick={() => loadTranscodes({ force: true })} disabled={loading}>
+          <RefreshLineIcon size={18} />
+          {loading ? "Refreshing" : "Refresh"}
+        </button>
+      </header>
+
+      {error ? <div className="transcodes-error">{error}</div> : null}
+
+      <section className="transcode-summary-grid">
+        <article>
+          <CpuLineIcon />
+          <strong>{formatNumber(activeCount)}</strong>
+          <span>Active</span>
+        </article>
+        <article>
+          <ListCheck2Icon />
+          <strong>{formatNumber(queueCount)}</strong>
+          <span>Queue</span>
+        </article>
+        <article>
+          <HistoryLineIcon />
+          <strong>{formatNumber(processedCount)}</strong>
+          <span>Processed</span>
+        </article>
+        <article>
+          <HistoryLineIcon />
+          <strong>{formatNumber(erroredCount)}</strong>
+          <span>Errored</span>
+        </article>
+        <article>
+          <CpuLineIcon />
+          <strong>{savedSize || "0 B"}</strong>
+          <span>Saved</span>
+        </article>
+      </section>
+
+      <nav className="transcode-tabs" aria-label="Transcode lists">
+        {tabs.map(({ key, label, Icon }) => (
+          <button type="button" className={activeTab === key ? "is-active" : ""} onClick={() => setActiveTab(key)} key={key}>
+            <Icon size={17} />
+            {label}
+          </button>
+        ))}
+      </nav>
+
+      <section className="transcode-list">
+        {jobs.map((job, index) => (
+          <JobCard job={job} kind={activeTab} key={`${job.id}-${index}`} />
+        ))}
+        {!jobs.length ? (
+          <div className="transcode-empty">
+            <strong>{loading ? "Loading Tdarr jobs" : `No ${activeTab} transcodes`}</strong>
+            <span>
+              {loading
+                ? "Checking the Tdarr server now."
+                : activeTab === "queued" && queueCount > 0
+                  ? `Tdarr reports ${formatNumber(queueCount)} queued item${queueCount === 1 ? "" : "s"}, but this API response only exposed counts.`
+                  : activeTab === "active" && activeCount > 0
+                    ? `Tdarr reports ${formatNumber(activeCount)} active worker${activeCount === 1 ? "" : "s"}, but this API response did not expose file rows.`
+                    : "This list will fill when Tdarr exposes jobs in this state."}
+            </span>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/pages/automation-health.jsx
+++ b/apps/web/src/pages/automation-health.jsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useState } from "react";
+import CheckboxCircleLineIcon from "remixicon-react/CheckboxCircleLineIcon";
+import ErrorWarningLineIcon from "remixicon-react/ErrorWarningLineIcon";
+import RefreshLineIcon from "remixicon-react/RefreshLineIcon";
+import RadarLineIcon from "remixicon-react/RadarLineIcon";
+import axios from "../lib/axios_instance";
+import "./css/automation-health.css";
+
+function formatNumber(value) {
+  return new Intl.NumberFormat("en-GB").format(Number(value || 0));
+}
+
+function ServiceCard({ service }) {
+  const isBazarr = service.type === "bazarr";
+  return (
+    <article className={`automation-service-card ${service.ok ? "is-ok" : "is-warning"}`}>
+      <div className="automation-service-head">
+        <span>
+          {service.ok ? <CheckboxCircleLineIcon /> : <ErrorWarningLineIcon />}
+        </span>
+        <div>
+          <h2>{service.name}</h2>
+          <p>{isBazarr ? "Subtitle status" : "Indexer status"}{service.version ? ` · ${service.version}` : ""}</p>
+        </div>
+      </div>
+
+      <div className="automation-service-metrics">
+        {isBazarr ? (
+          <>
+            <span><strong>{formatNumber(service.stats?.missingEpisodes)}</strong>Missing episodes</span>
+            <span><strong>{formatNumber(service.stats?.missingMovies)}</strong>Missing movies</span>
+            <span><strong>{formatNumber(service.history?.length)}</strong>Recent grabs</span>
+          </>
+        ) : (
+          <>
+            <span><strong>{formatNumber(service.stats?.indexers)}</strong>Indexers</span>
+            <span><strong>{formatNumber(service.stats?.failedIndexers)}</strong>Failed</span>
+            <span><strong>{formatNumber(service.stats?.applications)}</strong>Apps</span>
+          </>
+        )}
+      </div>
+
+      {service.issues?.length ? (
+        <div className="automation-issues">
+          <strong>Issues</strong>
+          {service.issues.slice(0, 6).map((issue) => (
+            <p key={issue.id || issue.message}>
+              <b>{issue.source}</b>
+              <span>{issue.message}</span>
+            </p>
+          ))}
+        </div>
+      ) : null}
+
+      {isBazarr && service.wanted?.length ? (
+        <div className="automation-list">
+          <strong>Missing subtitles</strong>
+          {service.wanted.slice(0, 8).map((item) => (
+            <p key={`${item.id}-${item.title}`}>
+              <span>{item.title}</span>
+              <small>{[item.type, item.language].filter(Boolean).join(" · ")}</small>
+            </p>
+          ))}
+        </div>
+      ) : null}
+
+      {!isBazarr && service.indexers?.length ? (
+        <div className="automation-list">
+          <strong>Indexers</strong>
+          {service.indexers.slice(0, 10).map((indexer) => (
+            <p key={indexer.id}>
+              <span>{indexer.name}</span>
+              <small>{indexer.failure || indexer.disabledTill || (indexer.enabled ? "Healthy" : "Disabled")}</small>
+            </p>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export default function AutomationHealth() {
+  const [data, setData] = useState({ services: [], stats: {} });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const services = useMemo(() => data.services || [], [data.services]);
+
+  async function loadAutomationHealth() {
+    try {
+      setError("");
+      const response = await axios.get("/api/automation-health");
+      setData(response.data || { services: [], stats: {} });
+    } catch (requestError) {
+      setError(requestError.response?.data?.error || "Unable to load automation health.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadAutomationHealth();
+    const intervalId = window.setInterval(loadAutomationHealth, 60000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  return (
+    <div className="automation-health-page">
+      <header className="automation-health-header">
+        <div>
+          <p>Automation Health</p>
+          <h1>Bazarr & Prowlarr</h1>
+          <span>Subtitle gaps, recent grabs, indexer health, failed indexers, and app sync status.</span>
+        </div>
+        <button type="button" onClick={loadAutomationHealth} disabled={loading}>
+          <RefreshLineIcon size={18} />
+          {loading ? "Refreshing" : "Refresh"}
+        </button>
+      </header>
+
+      {error ? <div className="automation-health-error">{error}</div> : null}
+
+      <section className="automation-summary-grid">
+        <article><RadarLineIcon /><strong>{formatNumber(data.stats?.services)}</strong><span>Services</span></article>
+        <article><CheckboxCircleLineIcon /><strong>{formatNumber(data.stats?.healthy)}</strong><span>Healthy</span></article>
+        <article><ErrorWarningLineIcon /><strong>{formatNumber(data.stats?.issues)}</strong><span>Issues</span></article>
+        <article><ErrorWarningLineIcon /><strong>{formatNumber(data.stats?.missingSubtitles)}</strong><span>Missing subtitles</span></article>
+        <article><ErrorWarningLineIcon /><strong>{formatNumber(data.stats?.failedIndexers)}</strong><span>Failed indexers</span></article>
+      </section>
+
+      <section className="automation-service-grid">
+        {services.map((service) => <ServiceCard key={service.id} service={service} />)}
+        {!services.length ? (
+          <div className="automation-empty">
+            <strong>{loading ? "Loading automation health" : "No Bazarr or Prowlarr integrations"}</strong>
+            <span>Connect Bazarr or Prowlarr in Settings &gt; Integrations &gt; Arr Apps.</span>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/pages/components/HomeStatisticCards.jsx
+++ b/apps/web/src/pages/components/HomeStatisticCards.jsx
@@ -14,8 +14,9 @@ import "../css/statCard.css";
 import { Trans } from "react-i18next";
 import PlaybackMethodStats from "./statCards/playback_method_stats";
 
-function HomeStatisticCards({ days: controlledDays }) {
+function HomeStatisticCards({ days: controlledDays, variant = "default" }) {
   const isControlled = controlledDays !== undefined && controlledDays !== null;
+  const isMediaRankings = variant === "media-rankings";
   const [days, setDays] = useState(localStorage.getItem("PREF_HOME_STAT_DAYS") ?? 30);
   const [input, setInput] = useState(localStorage.getItem("PREF_HOME_STAT_DAYS") ?? 30);
   const activeDays = isControlled ? controlledDays : days;
@@ -36,11 +37,15 @@ function HomeStatisticCards({ days: controlledDays }) {
     <div className="watch-stat-cards">
       <div className="Heading my-3">
         <div>
-          <p className="stat-section-eyebrow">Overview</p>
+          <p className="stat-section-eyebrow">{isMediaRankings ? "Rankings" : "Overview"}</p>
           <h1>
-            <Trans i18nKey="HOME_PAGE.WATCH_STATISTIC" />
+            {isMediaRankings ? "Media rankings" : <Trans i18nKey="HOME_PAGE.WATCH_STATISTIC" />}
           </h1>
-          <span className="stat-section-subtitle">Top libraries, users, clients, and playback methods for this window.</span>
+          <span className="stat-section-subtitle">
+            {isMediaRankings
+              ? "Most watched and most popular media for this window."
+              : "Top libraries, users, clients, and playback methods for this window."}
+          </span>
         </div>
         {!isControlled && (
           <div className="date-range">
@@ -69,10 +74,14 @@ function HomeStatisticCards({ days: controlledDays }) {
         <MPSeries days={activeDays} />
         <MVMusic days={activeDays} />
         <MPMusic days={activeDays} />
-        <MVLibraries days={activeDays} />
-        <MostUsedClient days={activeDays} />
-        <MostActiveUsers days={activeDays} />
-        <PlaybackMethodStats days={activeDays} />
+        {!isMediaRankings && (
+          <>
+            <MVLibraries days={activeDays} />
+            <MostUsedClient days={activeDays} />
+            <MostActiveUsers days={activeDays} />
+            <PlaybackMethodStats days={activeDays} />
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/pages/components/LibrarySelector/SelectionCard.jsx
+++ b/apps/web/src/pages/components/LibrarySelector/SelectionCard.jsx
@@ -65,7 +65,9 @@ function SelectionCard(props) {
           <Card.Img
             variant="top"
             className="library-card-banner default_library_image"
-            src={baseUrl + "/proxy/Items/Images/Primary?id=" + props.data.Id + "&fillWidth=800&quality=50"}
+            src={baseUrl + "/proxy/Items/Images/Primary?id=" + props.data.Id + "&fillWidth=520&quality=48"}
+            loading="lazy"
+            decoding="async"
             onError={() => setImageLoaded(false)}
           />
         ) : (

--- a/apps/web/src/pages/components/activity/activity-table.jsx
+++ b/apps/web/src/pages/components/activity/activity-table.jsx
@@ -57,6 +57,9 @@ const colors = {
 };
 const token = localStorage.getItem("token");
 const activityColumnVisibilityKey = "PREF_ACTIVITY_ColumnVisibility";
+const defaultColumnVisibility = {
+  RemoteEndPoint: false,
+};
 
 function getCssVariableColor(variableName, fallback) {
   if (typeof window === "undefined") {
@@ -90,11 +93,35 @@ function ActivityPoster({ itemId, title }) {
   );
 }
 
+function ActivityUserAvatar({ userId, userName }) {
+  const [imageFailed, setImageFailed] = React.useState(!userId);
+  const initial = userName?.slice(0, 1)?.toUpperCase() || "?";
+
+  if (imageFailed) {
+    return (
+      <span className="activity-user-avatar activity-user-avatar-fallback" aria-hidden="true">
+        {initial}
+      </span>
+    );
+  }
+
+  return (
+    <img
+      className="activity-user-avatar"
+      src={`/proxy/Users/Images/Primary?id=${userId}&fillWidth=72&quality=72`}
+      alt=""
+      loading="lazy"
+      decoding="async"
+      onError={() => setImageFailed(true)}
+    />
+  );
+}
+
 function getStoredColumnVisibility() {
   try {
-    return JSON.parse(localStorage.getItem(activityColumnVisibilityKey) || "{}");
+    return { ...defaultColumnVisibility, ...JSON.parse(localStorage.getItem(activityColumnVisibilityKey) || "{}") };
   } catch {
-    return {};
+    return defaultColumnVisibility;
   }
 }
 
@@ -208,47 +235,16 @@ export default function ActivityTable(props) {
 
   const columns = [
     {
-      accessorKey: "UserName",
-      header: i18next.t("USER"),
-      Cell: ({ row }) => {
-        row = row.original;
-        return (
-          <Link to={`/users/${row.UserId}`} className="activity-table-link activity-user-link">
-            {row.UserName}
-          </Link>
-        );
-      },
-    },
-    {
-      accessorKey: "RemoteEndPoint",
-      header: i18next.t("ACTIVITY_TABLE.IP_ADDRESS"),
-
-      Cell: ({ row }) => {
-        row = row.original;
-        if (
-          isRemoteSession(row.RemoteEndPoint) &&
-          (window.env?.JS_GEOLITE_ACCOUNT_ID ?? import.meta.env.JS_GEOLITE_ACCOUNT_ID) != undefined
-        ) {
-          return (
-            <Link className="activity-table-link" onClick={() => showIPDataModal(row.RemoteEndPoint)}>
-              {row.RemoteEndPoint}
-            </Link>
-          );
-        } else {
-          return <span>{row.RemoteEndPoint || "-"}</span>;
-        }
-      },
-    },
-    {
       accessorFn: (row) =>
         `${
           !row?.SeriesName
             ? row.NowPlayingItemName
             : row.SeriesName + " : S" + row.SeasonNumber + "E" + row.EpisodeNumber + " - " + row.NowPlayingItemName
-        }`,
+      }`,
       field: "NowPlayingItemName",
       header: i18next.t("TITLE"),
-      minSize: 300,
+      minSize: 360,
+      grow: 1.6,
       Cell: ({ row }) => {
         row = row.original;
         const title = !row.SeriesName
@@ -260,8 +256,25 @@ export default function ActivityTable(props) {
           <Link to={`/libraries/item/${row.EpisodeId || row.NowPlayingItemId}`} className="activity-table-link activity-title-link">
             <span className="activity-title-media">
               <ActivityPoster itemId={itemId} title={title} />
-              <span className="activity-title-copy">{title}</span>
+              <span className="activity-title-copy">
+                <strong>{title}</strong>
+                <small>{row.SeriesName ? "Episode" : row.NowPlayingItemName ? "Movie" : "Media"}</small>
+              </span>
             </span>
+          </Link>
+        );
+      },
+    },
+    {
+      accessorKey: "UserName",
+      header: i18next.t("USER"),
+      size: 190,
+      Cell: ({ row }) => {
+        row = row.original;
+        return (
+          <Link to={`/users/${row.UserId}`} className="activity-table-link activity-user-link">
+            <ActivityUserAvatar userId={row.UserId} userName={row.UserName} />
+            <span>{row.UserName || "Unknown"}</span>
           </Link>
         );
       },
@@ -269,6 +282,7 @@ export default function ActivityTable(props) {
     {
       accessorKey: "Client",
       header: i18next.t("ACTIVITY_TABLE.CLIENT"),
+      size: 160,
       Cell: ({ row }) => {
         row = row.original;
         return (
@@ -279,8 +293,15 @@ export default function ActivityTable(props) {
       },
     },
     {
+      accessorKey: "DeviceName",
+      header: i18next.t("ACTIVITY_TABLE.DEVICE"),
+      size: 180,
+      Cell: ({ cell }) => <span className="activity-device-cell">{cell.getValue() || "-"}</span>,
+    },
+    {
       accessorKey: "PlayMethod",
       header: i18next.t("TRANSCODE"),
+      size: 160,
       Cell: ({ row }) => {
         row = row.original;
         if (row.PlayMethod === "Transcode") {
@@ -321,14 +342,10 @@ export default function ActivityTable(props) {
       },
     },
     {
-      accessorKey: "DeviceName",
-      header: i18next.t("ACTIVITY_TABLE.DEVICE"),
-    },
-    {
       accessorFn: (row) => new Date(row.ActivityDateInserted),
       field: "ActivityDateInserted",
       header: i18next.t("DATE"),
-      size: 110,
+      size: 170,
       filterVariant: "date-range",
       Cell: ({ row }) => {
         const options = {
@@ -345,9 +362,28 @@ export default function ActivityTable(props) {
       },
     },
     {
+      accessorKey: "RemoteEndPoint",
+      header: i18next.t("ACTIVITY_TABLE.IP_ADDRESS"),
+      size: 150,
+      Cell: ({ row }) => {
+        row = row.original;
+        if (
+          isRemoteSession(row.RemoteEndPoint) &&
+          (window.env?.JS_GEOLITE_ACCOUNT_ID ?? import.meta.env.JS_GEOLITE_ACCOUNT_ID) != undefined
+        ) {
+          return (
+            <Link className="activity-table-link activity-ip-link" onClick={() => showIPDataModal(row.RemoteEndPoint)}>
+              {row.RemoteEndPoint}
+            </Link>
+          );
+        }
+        return <span className="activity-ip-cell">{row.RemoteEndPoint || "-"}</span>;
+      },
+    },
+    {
       accessorKey: "PlaybackDuration",
       header: i18next.t("ACTIVITY_TABLE.TOTAL_PLAYBACK"),
-      minSize: 200,
+      size: 160,
       // filterFn: (row, id, filterValue) => formatTotalWatchTime(row.getValue(id)).startsWith(filterValue),
       filterVariant: "range",
       Cell: ({ cell }) => <span className="activity-duration-cell">{formatTotalWatchTime(cell.getValue())}</span>,
@@ -357,6 +393,7 @@ export default function ActivityTable(props) {
       field: "TotalPlays",
       header: i18next.t("TOTAL_PLAYS"),
       filterFn: "betweenInclusive",
+      size: 110,
 
       Cell: ({ cell }) => <span className="activity-plays-cell">{cell.getValue() ?? 1}</span>,
     },
@@ -708,7 +745,7 @@ export default function ActivityTable(props) {
           </button>
         </Modal.Footer>
       </Modal>
-      <Modal show={modalState} onHide={() => setModalState(false)}>
+      <Modal show={modalState} onHide={() => setModalState(false)} dialogClassName="stream-info-modal">
         <Modal.Header>
           <Modal.Title>
             <Trans i18nKey="ACTIVITY_TABLE.MODAL.HEADER" />

--- a/apps/web/src/pages/components/activity/stream_info.jsx
+++ b/apps/web/src/pages/components/activity/stream_info.jsx
@@ -1,226 +1,236 @@
 import React from "react";
 import "../../css/activity/stream-info.css";
-// import { Button } from "react-bootstrap";
 import Loading from "../general/loading";
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
 import { Trans } from "react-i18next";
 import i18next from "i18next";
 
+const UNKNOWN_VALUE = "-";
 
-
-function Row(logs) {
-    const { data } = logs;
-
-  function convertBitrate(bitrate) {
-    if(!bitrate)
-    {
-      return '-';
-    }
-    const kbps = (bitrate / 1000).toFixed(1);
-    const mbps = (bitrate / 1000000).toFixed(1);
-  
-    if (kbps >= 1000) {
-      return  mbps+' Mbps';
-    } else {
-      return  kbps+' Kbps';
-    }
+function convertBitrate(bitrate) {
+  const numericBitrate = Number(bitrate);
+  if (!Number.isFinite(numericBitrate) || numericBitrate <= 0) {
+    return UNKNOWN_VALUE;
   }
 
-  if(!data || !data.MediaStreams)
-  {
+  const kbps = numericBitrate / 1000;
+  if (kbps >= 1000) {
+    return `${(numericBitrate / 1000000).toFixed(1)} Mbps`;
+  }
+  return `${kbps.toFixed(1)} Kbps`;
+}
+
+function formatValue(value) {
+  if (value === undefined || value === null || value === "") {
+    return UNKNOWN_VALUE;
+  }
+  return value;
+}
+
+function formatUpper(value) {
+  const formattedValue = formatValue(value);
+  return formattedValue === UNKNOWN_VALUE ? UNKNOWN_VALUE : String(formattedValue).toUpperCase();
+}
+
+function streamMode(data, type) {
+  if (data.PlayMethod === "DirectStream") {
+    return i18next.t("DIRECT_STREAM");
+  }
+
+  if (!data.TranscodingInfo) {
+    return i18next.t("DIRECT");
+  }
+
+  const isDirect = type === "video" ? data.TranscodingInfo?.IsVideoDirect : data.TranscodingInfo?.IsAudioDirect;
+  return isDirect ? i18next.t("DIRECT") : i18next.t("TRANSCODE");
+}
+
+function modeClass(mode) {
+  return `is-${String(mode).toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+}
+
+function DetailRow({ label, stream, source }) {
+  return (
+    <div className="stream-info-row">
+      <span>{label}</span>
+      <strong>{stream}</strong>
+      <strong>{source}</strong>
+    </div>
+  );
+}
+
+function DetailSection({ title, mode, rows }) {
+  return (
+    <section className="stream-info-section">
+      <div className="stream-info-section-header">
+        <h3>{title}</h3>
+        {mode ? <span className={`stream-info-mode ${modeClass(mode)}`}>{mode}</span> : null}
+      </div>
+      <div className="stream-info-row stream-info-columns" aria-hidden="true">
+        <span />
+        <strong>
+          <Trans i18nKey="STREAM_DETAILS" />
+        </strong>
+        <strong>
+          <Trans i18nKey="SOURCE_DETAILS" />
+        </strong>
+      </div>
+      <div className="stream-info-rows">{rows}</div>
+    </section>
+  );
+}
+
+function StreamDetails({ data }) {
+  if (!data || !data.MediaStreams) {
     return null;
   }
 
-  const UNKNOWN_VALUE = '-';
-  const videoStream = data?.MediaStreams.find(stream => stream.Type === 'Video');
-  const audioStream = data?.MediaStreams.find(stream => stream.Type === 'Audio');
+  const videoStream = data.MediaStreams.find((stream) => stream.Type === "Video");
+  const audioStream = data.MediaStreams.find((stream) => stream.Type === "Audio");
 
-  let overallOriginalBitrateRaw = 0;
-  if (videoStream && videoStream.BitRate) {
-    overallOriginalBitrateRaw = videoStream.BitRate;
-  }
-  if (audioStream && audioStream.BitRate) {
-    overallOriginalBitrateRaw += audioStream.BitRate;
-  }
-  const overallOriginalBitrate = convertBitrate(overallOriginalBitrateRaw);
+  const originalBitrateRaw = Number(videoStream?.BitRate || 0) + Number(audioStream?.BitRate || 0);
+  const overallOriginalBitrate = convertBitrate(originalBitrateRaw);
 
-  let overallTranscodeBitrateRaw = 0;
+  let transcodeBitrateRaw = originalBitrateRaw;
   if (data.TranscodingInfo) {
-    if ((data.TranscodingInfo.IsVideoDirect === false && data.TranscodingInfo.VideoBitrate) || (data.TranscodingInfo.IsAudioDirect === false && data.TranscodingInfo.AudioBitrate)) {
-      overallTranscodeBitrateRaw += data.TranscodingInfo.IsVideoDirect === false ? data.TranscodingInfo.VideoBitrate : videoStream ? videoStream?.BitRate : 0;
-      overallTranscodeBitrateRaw += data.TranscodingInfo.IsAudioDirect === false ? data.TranscodingInfo.AudioBitrate : audioStream ? audioStream?.BitRate : 0;
+    if (
+      (data.TranscodingInfo.IsVideoDirect === false && data.TranscodingInfo.VideoBitrate) ||
+      (data.TranscodingInfo.IsAudioDirect === false && data.TranscodingInfo.AudioBitrate)
+    ) {
+      transcodeBitrateRaw += data.TranscodingInfo.IsVideoDirect === false ? Number(data.TranscodingInfo.VideoBitrate || 0) : 0;
+      transcodeBitrateRaw += data.TranscodingInfo.IsAudioDirect === false ? Number(data.TranscodingInfo.AudioBitrate || 0) : 0;
+      if (data.TranscodingInfo.IsVideoDirect === false && videoStream?.BitRate) {
+        transcodeBitrateRaw -= Number(videoStream.BitRate);
+      }
+      if (data.TranscodingInfo.IsAudioDirect === false && audioStream?.BitRate) {
+        transcodeBitrateRaw -= Number(audioStream.BitRate);
+      }
     } else {
-      overallTranscodeBitrateRaw = data.TranscodingInfo?.Bitrate;
+      transcodeBitrateRaw = data.TranscodingInfo?.Bitrate;
     }
-  } else {
-    overallTranscodeBitrateRaw = overallOriginalBitrateRaw;
-  }
-  const overallTranscodeBitrate = convertBitrate(overallTranscodeBitrateRaw);
-
-  let videoTranscodeBitrate = UNKNOWN_VALUE;
-  if (data.TranscodingInfo && data.TranscodingInfo?.IsVideoDirect === false) {
-    videoTranscodeBitrate = convertBitrate(data.TranscodingInfo.VideoBitrate ? data.TranscodingInfo.VideoBitrate : data.TranscodingInfo.Bitrate);
-  } else if (videoStream) {
-    videoTranscodeBitrate = convertBitrate(videoStream?.BitRate);
   }
 
-    return (
-      <React.Fragment>
+  const videoTranscodeBitrate =
+    data.TranscodingInfo && data.TranscodingInfo?.IsVideoDirect === false
+      ? convertBitrate(data.TranscodingInfo.VideoBitrate || data.TranscodingInfo.Bitrate)
+      : convertBitrate(videoStream?.BitRate);
+  const videoMode = streamMode(data, "video");
+  const audioMode = streamMode(data, "audio");
+  const transcodeReasons = data.TranscodingInfo?.TranscodeReasons || [];
 
-        <TableRow>
-          <TableCell colSpan="3"><strong><Trans i18nKey={"MEDIA"}/></strong></TableCell>
-        </TableRow>
+  return (
+    <>
+      <div className="stream-info-summary">
+        <div>
+          <span>Playback</span>
+          <strong>{data.PlayMethod || i18next.t("DIRECT")}</strong>
+        </div>
+        <div>
+          <span>Stream</span>
+          <strong>{convertBitrate(transcodeBitrateRaw)}</strong>
+        </div>
+        <div>
+          <span>Source</span>
+          <strong>{overallOriginalBitrate}</strong>
+        </div>
+      </div>
 
-        <TableRow>
-          <TableCell className="py-0 pb-1" ><Trans i18nKey={"BITRATE"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{overallTranscodeBitrate}</TableCell>
-          <TableCell className="py-0 pb-1" >{overallOriginalBitrate}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-1" ><Trans i18nKey={"CONTAINER"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{data.TranscodingInfo ? data.TranscodingInfo.Container.toUpperCase() : data.OriginalContainer.toUpperCase()}</TableCell>
-          <TableCell className="py-0 pb-1" >{data.OriginalContainer.toUpperCase()}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell ><strong><Trans i18nKey={"VIDEO"}/></strong></TableCell>
-          <TableCell colSpan="2" style={{textTransform:"uppercase"}}><strong>
-            {data.PlayMethod === "DirectStream" ? 
-              i18next.t("DIRECT_STREAM") : 
-              (data.TranscodingInfo ? 
-                (data.TranscodingInfo?.IsVideoDirect ? i18next.t("DIRECT") : i18next.t("TRANSCODE")) : 
-                i18next.t("DIRECT"))}
-          </strong></TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-1" ><Trans i18nKey={"CODEC"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{data.TranscodingInfo ? data.TranscodingInfo.VideoCodec?.toUpperCase() : videoStream ? videoStream.Codec?.toUpperCase() : UNKNOWN_VALUE}</TableCell>
-          <TableCell className="py-0 pb-1" >{videoStream ? videoStream?.Codec?.toUpperCase() : UNKNOWN_VALUE}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-3" ><Trans i18nKey={"BITRATE"}/></TableCell>
-          <TableCell className="py-0 pb-3" >{videoTranscodeBitrate}</TableCell>
-          <TableCell className="py-0 pb-3" >{convertBitrate(videoStream ? videoStream?.BitRate : null)}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-1" ><Trans i18nKey={"WIDTH"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{data.TranscodingInfo ? data.TranscodingInfo.Width : videoStream ? videoStream?.Width : UNKNOWN_VALUE}</TableCell>
-          <TableCell className="py-0 pb-1" >{videoStream ? videoStream?.Width : UNKNOWN_VALUE}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-3" ><Trans i18nKey={"HEIGHT"}/></TableCell>
-          <TableCell className="py-0 pb-3" >{data.TranscodingInfo ? data.TranscodingInfo?.Height : videoStream ? videoStream?.Height : UNKNOWN_VALUE}</TableCell>
-          <TableCell className="py-0 pb-3" >{videoStream ? videoStream?.Height : UNKNOWN_VALUE}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-1" ><Trans i18nKey={"FRAMERATE"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{videoStream ? parseFloat(videoStream.RealFrameRate.toFixed(2)) : UNKNOWN_VALUE}</TableCell>
-          <TableCell className="py-0 pb-1" >{videoStream ? parseFloat(videoStream.RealFrameRate.toFixed(2)) : UNKNOWN_VALUE}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-1" ><Trans i18nKey={"DYNAMIC_RANGE"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{videoStream ? videoStream?.VideoRange : UNKNOWN_VALUE}</TableCell>
-          <TableCell className="py-0 pb-1" >{videoStream ? videoStream?.VideoRange : UNKNOWN_VALUE}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-1" ><Trans i18nKey={"ASPECT_RATIO"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{videoStream ? videoStream?.AspectRatio : UNKNOWN_VALUE}</TableCell>
-          <TableCell className="py-0 pb-1" >{videoStream ? videoStream?.AspectRatio : UNKNOWN_VALUE}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell ><strong><Trans i18nKey={"AUDIO"}/></strong></TableCell>
-          <TableCell colSpan="2" style={{textTransform:"uppercase"}}><strong>
-            {data.PlayMethod === "DirectStream" ? 
-              i18next.t("DIRECT_STREAM") : 
-              (data.TranscodingInfo ? 
-                (data.TranscodingInfo?.IsAudioDirect ? i18next.t("DIRECT") : i18next.t("TRANSCODE")) : 
-                i18next.t("DIRECT"))}
-          </strong></TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-1" ><Trans i18nKey={"CODEC"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{data.TranscodingInfo ? data.TranscodingInfo.AudioCodec?.toUpperCase() : audioStream ? audioStream?.Codec?.toUpperCase() : UNKNOWN_VALUE}</TableCell>
-          <TableCell className="py-0 pb-1" >{audioStream ? audioStream?.Codec?.toUpperCase() : UNKNOWN_VALUE}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-1" ><Trans i18nKey={"BITRATE"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{convertBitrate(data.TranscodingInfo ? data.TranscodingInfo.AudioBitrate ? data.TranscodingInfo.AudioBitrate : UNKNOWN_VALUE : audioStream ? audioStream?.BitRate : null)}</TableCell>
-          <TableCell className="py-0 pb-1" >{convertBitrate(audioStream ? audioStream?.BitRate : null)}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell  className="py-0 pb-1"><Trans i18nKey={"CHANNELS"}/></TableCell>
-          <TableCell  className="py-0 pb-1">{data.TranscodingInfo && data.TranscodingInfo?.IsAudioDirect === false ? data.TranscodingInfo?.AudioChannels : audioStream ? audioStream?.Channels : UNKNOWN_VALUE}</TableCell>
-          <TableCell  className="py-0 pb-1">{audioStream ? audioStream?.Channels : null}</TableCell>
-        </TableRow>
-
-        <TableRow>
-          <TableCell className="py-0 pb-3" ><Trans i18nKey={"LANGUAGE"}/></TableCell>
-          <TableCell className="py-0 pb-3" >{audioStream ? audioStream?.Language?.toUpperCase() : UNKNOWN_VALUE}</TableCell>
-          <TableCell className="py-0 pb-3" >{audioStream ? audioStream?.Language?.toUpperCase() : UNKNOWN_VALUE}</TableCell>
-        </TableRow>
-
-        {data.TranscodingInfo && data.TranscodingInfo?.TranscodeReasons && data.TranscodingInfo.TranscodeReasons.length > 0 && (
+      <DetailSection
+        title={<Trans i18nKey="MEDIA" />}
+        rows={
           <>
-            <TableRow>
-              <TableCell colSpan="3"><strong><Trans i18nKey={"TRANSCODE_REASONS"}/></strong></TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell className="py-0 pb-3" colSpan="3">{data.TranscodingInfo.TranscodeReasons.join(", ")}</TableCell>
-            </TableRow>
+            <DetailRow label={<Trans i18nKey="BITRATE" />} stream={convertBitrate(transcodeBitrateRaw)} source={overallOriginalBitrate} />
+            <DetailRow
+              label={<Trans i18nKey="CONTAINER" />}
+              stream={formatUpper(data.TranscodingInfo ? data.TranscodingInfo.Container : data.OriginalContainer)}
+              source={formatUpper(data.OriginalContainer)}
+            />
           </>
-        )}
+        }
+      />
 
-      </React.Fragment>
-    );
-  }
-  
+      <DetailSection
+        title={<Trans i18nKey="VIDEO" />}
+        mode={videoMode}
+        rows={
+          <>
+            <DetailRow
+              label={<Trans i18nKey="CODEC" />}
+              stream={formatUpper(data.TranscodingInfo ? data.TranscodingInfo.VideoCodec : videoStream?.Codec)}
+              source={formatUpper(videoStream?.Codec)}
+            />
+            <DetailRow label={<Trans i18nKey="BITRATE" />} stream={videoTranscodeBitrate} source={convertBitrate(videoStream?.BitRate)} />
+            <DetailRow
+              label={<Trans i18nKey="WIDTH" />}
+              stream={formatValue(data.TranscodingInfo ? data.TranscodingInfo.Width : videoStream?.Width)}
+              source={formatValue(videoStream?.Width)}
+            />
+            <DetailRow
+              label={<Trans i18nKey="HEIGHT" />}
+              stream={formatValue(data.TranscodingInfo ? data.TranscodingInfo.Height : videoStream?.Height)}
+              source={formatValue(videoStream?.Height)}
+            />
+            <DetailRow
+              label={<Trans i18nKey="FRAMERATE" />}
+              stream={videoStream?.RealFrameRate ? parseFloat(videoStream.RealFrameRate.toFixed(2)) : UNKNOWN_VALUE}
+              source={videoStream?.RealFrameRate ? parseFloat(videoStream.RealFrameRate.toFixed(2)) : UNKNOWN_VALUE}
+            />
+            <DetailRow label={<Trans i18nKey="DYNAMIC_RANGE" />} stream={formatValue(videoStream?.VideoRange)} source={formatValue(videoStream?.VideoRange)} />
+            <DetailRow label={<Trans i18nKey="ASPECT_RATIO" />} stream={formatValue(videoStream?.AspectRatio)} source={formatValue(videoStream?.AspectRatio)} />
+          </>
+        }
+      />
+
+      <DetailSection
+        title={<Trans i18nKey="AUDIO" />}
+        mode={audioMode}
+        rows={
+          <>
+            <DetailRow
+              label={<Trans i18nKey="CODEC" />}
+              stream={formatUpper(data.TranscodingInfo ? data.TranscodingInfo.AudioCodec : audioStream?.Codec)}
+              source={formatUpper(audioStream?.Codec)}
+            />
+            <DetailRow
+              label={<Trans i18nKey="BITRATE" />}
+              stream={convertBitrate(data.TranscodingInfo?.IsAudioDirect === false ? data.TranscodingInfo.AudioBitrate : audioStream?.BitRate)}
+              source={convertBitrate(audioStream?.BitRate)}
+            />
+            <DetailRow
+              label={<Trans i18nKey="CHANNELS" />}
+              stream={formatValue(data.TranscodingInfo?.IsAudioDirect === false ? data.TranscodingInfo.AudioChannels : audioStream?.Channels)}
+              source={formatValue(audioStream?.Channels)}
+            />
+            <DetailRow label={<Trans i18nKey="LANGUAGE" />} stream={formatUpper(audioStream?.Language)} source={formatUpper(audioStream?.Language)} />
+          </>
+        }
+      />
+
+      {transcodeReasons.length > 0 ? (
+        <section className="stream-info-section stream-info-reasons">
+          <div className="stream-info-section-header">
+            <h3>
+              <Trans i18nKey="TRANSCODE_REASONS" />
+            </h3>
+          </div>
+          <div className="stream-info-reason-list">
+            {transcodeReasons.map((reason) => (
+              <span key={reason}>{reason}</span>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </>
+  );
+}
 
 function StreamInfo(props) {
-
-
-  if(!props && !props.data)
-  {
-    return <Loading/>;
+  if (!props?.data) {
+    return <Loading />;
   }
-
-  
 
   return (
     <div className="StreamInfo">
- 
-      <TableContainer className="overflow-hidden">
-                    <Table aria-label="collapsible table" >
-                      <TableHead>
-                        <TableRow>
-                          <TableCell/>
-                          <TableCell><Trans i18nKey={"STREAM_DETAILS"}/></TableCell>
-                          <TableCell><Trans i18nKey={"SOURCE_DETAILS"}/></TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                            <Row data={props.data} />
-
-                      </TableBody>
-                    </Table>
-            </TableContainer>
-
+      <StreamDetails data={props.data} />
     </div>
   );
 }

--- a/apps/web/src/pages/components/general/WhatsNewModal.jsx
+++ b/apps/web/src/pages/components/general/WhatsNewModal.jsx
@@ -7,10 +7,10 @@ import SpeedLineIcon from "remixicon-react/SpeedLineIcon";
 import Movie2LineIcon from "remixicon-react/Movie2LineIcon";
 import MailLineIcon from "remixicon-react/MailLineIcon";
 import axios from "../../../lib/axios_instance";
+import { APP_VERSION_STORAGE_KEY, OPEN_WHATS_NEW_EVENT } from "../../../lib/events";
 import releaseNotes from "../../../whats-new.json";
 
 const SEEN_VERSION_KEY = "jellyglance_whats_new_seen_version";
-export const OPEN_WHATS_NEW_EVENT = "jellyglance-open-whats-new";
 
 const iconMap = {
   magic: MagicLineIcon,
@@ -41,6 +41,15 @@ export default function WhatsNewModal({ enabled = true }) {
 
   useEffect(() => {
     if (!enabled) return;
+
+    const cachedVersion = localStorage.getItem(APP_VERSION_STORAGE_KEY);
+    if (cachedVersion) {
+      setVersion(cachedVersion);
+      if (localStorage.getItem(SEEN_VERSION_KEY) !== cachedVersion) {
+        setShow(true);
+      }
+      return;
+    }
 
     let active = true;
     axios

--- a/apps/web/src/pages/components/general/navbar.jsx
+++ b/apps/web/src/pages/components/general/navbar.jsx
@@ -5,13 +5,15 @@ import axios from "../../../lib/axios_instance";
 import { navData } from "../../../lib/navdata";
 import LogoutBoxLineIcon from "remixicon-react/LogoutBoxLineIcon";
 import AccountCircleLineIcon from "remixicon-react/AccountCircleLineIcon";
+import ArrowLeftSLineIcon from "remixicon-react/ArrowLeftSLineIcon";
+import ArrowRightSLineIcon from "remixicon-react/ArrowRightSLineIcon";
 import MagicLineIcon from "remixicon-react/MagicLineIcon";
 import MenuLineIcon from "remixicon-react/MenuLineIcon";
 import logo_dark from "../../images/icon-b-512.png";
 import projectText from "../../images/project-text.png";
 import "../../css/navbar.css";
 import VersionCard from "./version-card";
-import { OPEN_WHATS_NEW_EVENT } from "./WhatsNewModal";
+import { OPEN_WHATS_NEW_EVENT } from "../../../lib/events";
 import { Trans } from "react-i18next";
 import baseUrl from "../../../lib/baseurl";
 import socket from "../../../socket";
@@ -19,6 +21,7 @@ import { slugifyUserName } from "../../../lib/userProfile";
 import Config from "../../../lib/config";
 import { FONT_WEIGHT_OPTIONS, getStoredFontWeight, saveFontWeightPreference } from "../../../lib/appearance";
 import { DEFAULT_THEME, THEME_PRESETS, getStoredTheme, resetTheme, saveTheme } from "../../../lib/theme";
+import { applyNavOrder, getStoredHiddenNavLinks, getStoredNavOrder, LOCKED_NAV_LINKS } from "../../../lib/nav-order";
 
 function getCachedConfig() {
   try {
@@ -31,6 +34,43 @@ function getCachedConfig() {
 const REQUEST_NAV_AVAILABLE_KEY = "jellyglance_request_nav_available";
 const DOWNLOAD_NAV_AVAILABLE_KEY = "jellyglance_download_nav_available";
 const WIZARR_NAV_AVAILABLE_KEY = "jellyglance_wizarr_nav_available";
+const TDARR_NAV_AVAILABLE_KEY = "jellyglance_tdarr_nav_available";
+const AUTOMATION_HEALTH_NAV_AVAILABLE_KEY = "jellyglance_automation_health_nav_available";
+const NAV_COLLAPSED_KEY = "jellyglance_nav_collapsed";
+const INTEGRATIONS_CACHE_TTL_MS = 10000;
+
+let integrationsCache = null;
+let integrationsCacheAt = 0;
+let integrationsRequest = null;
+
+async function loadNavbarIntegrations() {
+  const now = Date.now();
+  if (integrationsCache && now - integrationsCacheAt < INTEGRATIONS_CACHE_TTL_MS) {
+    return integrationsCache;
+  }
+
+  if (!integrationsRequest) {
+    integrationsRequest = axios
+      .get("/api/integrations", {
+        headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      })
+      .then((response) => {
+        integrationsCache = response.data || { arrApps: [], clients: [], thirdParty: [] };
+        integrationsCacheAt = Date.now();
+        return integrationsCache;
+      })
+      .finally(() => {
+        integrationsRequest = null;
+      });
+  }
+
+  return integrationsRequest;
+}
+
+function clearNavbarIntegrationsCache() {
+  integrationsCache = null;
+  integrationsCacheAt = 0;
+}
 
 function getCachedRequestNavAvailable() {
   return localStorage.getItem(REQUEST_NAV_AVAILABLE_KEY) === "true";
@@ -42,6 +82,18 @@ function getCachedDownloadNavAvailable() {
 
 function getCachedWizarrNavAvailable() {
   return localStorage.getItem(WIZARR_NAV_AVAILABLE_KEY) === "true";
+}
+
+function getCachedTdarrNavAvailable() {
+  return localStorage.getItem(TDARR_NAV_AVAILABLE_KEY) === "true";
+}
+
+function getCachedAutomationHealthNavAvailable() {
+  return localStorage.getItem(AUTOMATION_HEALTH_NAV_AVAILABLE_KEY) === "true";
+}
+
+function getCachedNavCollapsed() {
+  return localStorage.getItem(NAV_COLLAPSED_KEY) === "true";
 }
 
 function isConfiguredSeerrApp(app) {
@@ -83,12 +135,32 @@ function getWizarrAvailabilityFromIntegrations(integrations) {
   return Array.isArray(integrations?.thirdParty) && integrations.thirdParty.some(isConfiguredWizarrApp);
 }
 
+function isConfiguredTdarrApp(app) {
+  const name = String(app?.name || app?.slug || "").toLowerCase();
+  const values = app?.values || {};
+  return name.includes("tdarr") && Boolean(app?.connected) && Boolean(String(values.url || "").trim());
+}
+
+function getTdarrAvailabilityFromIntegrations(integrations) {
+  return Array.isArray(integrations?.thirdParty) && integrations.thirdParty.some(isConfiguredTdarrApp);
+}
+
+function isConfiguredAutomationHealthApp(app) {
+  const name = String(app?.name || app?.slug || "").toLowerCase();
+  const values = app?.values || {};
+  return (name.includes("bazarr") || name.includes("prowlarr")) && Boolean(app?.connected) && Boolean(String(values.url || "").trim()) && Boolean(String(values.secret || "").trim());
+}
+
+function getAutomationHealthAvailabilityFromIntegrations(integrations) {
+  return Array.isArray(integrations?.arrApps) && integrations.arrApps.some(isConfiguredAutomationHealthApp);
+}
+
 function isNavItemActive(item, location) {
   const pathname = location.pathname.toLocaleLowerCase();
   const navPath = String(item.link || "").split("?")[0].toLocaleLowerCase();
 
   if (item.link === "settings") {
-    return pathname === "/settings";
+    return pathname === "/settings" || pathname.startsWith("/settings/");
   }
 
   return (
@@ -105,12 +177,18 @@ export default function Navbar() {
   const [fontWeightPreference, setFontWeightPreference] = useState(() => getStoredFontWeight());
   const [activeStreamCount, setActiveStreamCount] = useState(0);
   const [activeDownloadCount, setActiveDownloadCount] = useState(() => Number(localStorage.getItem("jellyglance_active_download_count") || 0));
+  const [activeTranscodeCount, setActiveTranscodeCount] = useState(() => Number(localStorage.getItem("jellyglance_active_transcode_count") || 0));
   const [requestBadgeCount, setRequestBadgeCount] = useState(() => Number(localStorage.getItem("jellyglance_request_badge_count") || 0));
   const [showRequestsNav, setShowRequestsNav] = useState(() => getCachedRequestNavAvailable());
   const [showDownloadsNav, setShowDownloadsNav] = useState(() => getCachedDownloadNavAvailable());
   const [showWizarrNav, setShowWizarrNav] = useState(() => getCachedWizarrNavAvailable());
+  const [showTdarrNav, setShowTdarrNav] = useState(() => getCachedTdarrNavAvailable());
+  const [showAutomationHealthNav, setShowAutomationHealthNav] = useState(() => getCachedAutomationHealthNavAvailable());
+  const [navOrder, setNavOrder] = useState(() => getStoredNavOrder(navData));
+  const [hiddenNavLinks, setHiddenNavLinks] = useState(() => getStoredHiddenNavLinks(navData));
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const [isThemeMenuOpen, setIsThemeMenuOpen] = useState(false);
+  const [isNavCollapsed, setIsNavCollapsed] = useState(() => getCachedNavCollapsed());
   const authMode = config?.settings?.auth?.mode || (config?.requireLogin === false ? "quick-connect" : "local");
   const authLabel =
     config?.settings?.auth?.label ||
@@ -118,9 +196,10 @@ export default function Navbar() {
   const jellyfinUser = config?.settings?.auth?.jellyfinUser;
   const canUploadAvatar = authMode === "local" || authMode === "oidc";
   const accountName = jellyfinUser?.name || config?.username || authLabel;
-  const accountRole = authMode === "quick-connect" ? "Jellyfin User" : authMode === "oidc" ? "OIDC User" : "Local User";
   const currentRole = config?.settings?.auth?.role || "Viewer";
-  const showServerManagementNav = currentRole === "Owner" || currentRole === "Admin";
+  const isJellyfinAdmin = currentRole === "Owner" || currentRole === "Admin";
+  const accountRole = authMode === "quick-connect" ? (isJellyfinAdmin ? "Jellyfin Admin" : "Jellyfin User") : authMode === "oidc" ? "OIDC User" : "Local User";
+  const showServerManagementNav = isJellyfinAdmin;
   const jellyfinAvatar = jellyfinUser?.id ? `${baseUrl}/proxy/Users/Images/Primary?id=${jellyfinUser.id}&fillWidth=160&quality=80` : "";
   const avatarSrc = jellyfinAvatar || (canUploadAvatar ? customAvatar : "");
   const activeThemePreset = THEME_PRESETS.find(
@@ -132,14 +211,20 @@ export default function Navbar() {
   );
   const visibleNavData = useMemo(
     () =>
-      navData.filter((item) => {
-        if (item.link === "requests") return showRequestsNav;
-        if (item.link === "downloads") return showDownloadsNav;
-        if (item.link === "wizarr") return showWizarrNav;
-        if (item.link === "server-management") return showServerManagementNav;
-        return true;
-      }),
-    [showDownloadsNav, showRequestsNav, showServerManagementNav, showWizarrNav]
+      applyNavOrder(
+        navData.filter((item) => {
+          if (!LOCKED_NAV_LINKS.has(item.link) && hiddenNavLinks.includes(item.link)) return false;
+          if (item.link === "requests") return showRequestsNav;
+          if (item.link === "downloads") return showDownloadsNav;
+          if (item.link === "active-transcodes") return showTdarrNav;
+          if (item.link === "automation-health") return showAutomationHealthNav;
+          if (item.link === "wizarr") return showWizarrNav;
+          if (item.link === "server-management") return showServerManagementNav;
+          return true;
+        }),
+        navOrder
+      ),
+    [hiddenNavLinks, navOrder, showAutomationHealthNav, showDownloadsNav, showRequestsNav, showServerManagementNav, showTdarrNav, showWizarrNav]
   );
 
   const handleLogout = () => {
@@ -159,6 +244,64 @@ export default function Navbar() {
   const location = useLocation();
 
   useEffect(() => {
+    localStorage.setItem(NAV_COLLAPSED_KEY, String(isNavCollapsed));
+    document.documentElement.style.setProperty("--jg-sidebar-width", isNavCollapsed ? "78px" : "250px");
+  }, [isNavCollapsed]);
+
+  useEffect(() => {
+    function handleNavCollapsedUpdate(event) {
+      setIsNavCollapsed(Boolean(event.detail));
+    }
+
+    window.addEventListener("jellyglance-nav-collapsed-updated", handleNavCollapsedUpdate);
+    return () => window.removeEventListener("jellyglance-nav-collapsed-updated", handleNavCollapsedUpdate);
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const setAutomationHealthAvailability = (integrations) => {
+      const nextAvailable = getAutomationHealthAvailabilityFromIntegrations(integrations);
+      localStorage.setItem(AUTOMATION_HEALTH_NAV_AVAILABLE_KEY, String(nextAvailable));
+      if (isMounted) {
+        setShowAutomationHealthNav(nextAvailable);
+      }
+    };
+
+    const refreshAutomationHealthAvailability = async () => {
+      if (!localStorage.getItem("token")) {
+        setAutomationHealthAvailability({ arrApps: [] });
+        return;
+      }
+
+      try {
+        setAutomationHealthAvailability(await loadNavbarIntegrations());
+      } catch {
+        if (isMounted) {
+          setShowAutomationHealthNav(getCachedAutomationHealthNavAvailable());
+        }
+      }
+    };
+
+    const handleIntegrationsUpdated = (event) => {
+      if (event.detail) {
+        setAutomationHealthAvailability(event.detail);
+        return;
+      }
+      clearNavbarIntegrationsCache();
+      refreshAutomationHealthAvailability();
+    };
+
+    const startupTimer = window.setTimeout(refreshAutomationHealthAvailability, 500);
+    window.addEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
+    return () => {
+      isMounted = false;
+      window.removeEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
+      window.clearTimeout(startupTimer);
+    };
+  }, []);
+
+  useEffect(() => {
     let isMounted = true;
 
     const refreshConfig = async () => {
@@ -167,7 +310,7 @@ export default function Navbar() {
         return;
       }
 
-      const freshConfig = await Config.getConfig(true);
+      const freshConfig = await Config.getConfig();
       if (isMounted && !freshConfig?.response) {
         setConfig(freshConfig);
       }
@@ -181,6 +324,22 @@ export default function Navbar() {
       isMounted = false;
       window.removeEventListener("jellyglance-config-updated", refreshConfig);
       window.removeEventListener("storage", refreshConfig);
+    };
+  }, []);
+
+  useEffect(() => {
+    const refreshNavOrder = () => setNavOrder(getStoredNavOrder(navData));
+    const refreshNavVisibility = () => setHiddenNavLinks(getStoredHiddenNavLinks(navData));
+
+    window.addEventListener("jellyglance-nav-order-updated", refreshNavOrder);
+    window.addEventListener("jellyglance-nav-visibility-updated", refreshNavVisibility);
+    window.addEventListener("storage", refreshNavOrder);
+    window.addEventListener("storage", refreshNavVisibility);
+    return () => {
+      window.removeEventListener("jellyglance-nav-order-updated", refreshNavOrder);
+      window.removeEventListener("jellyglance-nav-visibility-updated", refreshNavVisibility);
+      window.removeEventListener("storage", refreshNavOrder);
+      window.removeEventListener("storage", refreshNavVisibility);
     };
   }, []);
 
@@ -217,10 +376,7 @@ export default function Navbar() {
       }
 
       try {
-        const response = await axios.get("/api/integrations", {
-          headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
-        });
-        setDownloadAvailability(response.data || { clients: [] });
+        setDownloadAvailability(await loadNavbarIntegrations());
       } catch {
         setShowDownloadsNav(getCachedDownloadNavAvailable());
       }
@@ -231,10 +387,11 @@ export default function Navbar() {
         setDownloadAvailability(event.detail);
         return;
       }
+      clearNavbarIntegrationsCache();
       refreshDownloadAvailability();
     };
 
-    refreshDownloadAvailability();
+    const startupTimer = window.setTimeout(refreshDownloadAvailability, 500);
     window.addEventListener("jellyglance-download-count", handleDownloadCount);
     window.addEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
     window.addEventListener("storage", handleDownloadCount);
@@ -242,6 +399,7 @@ export default function Navbar() {
       window.removeEventListener("jellyglance-download-count", handleDownloadCount);
       window.removeEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
       window.removeEventListener("storage", handleDownloadCount);
+      window.clearTimeout(startupTimer);
     };
   }, []);
 
@@ -263,10 +421,7 @@ export default function Navbar() {
       }
 
       try {
-        const response = await axios.get("/api/integrations", {
-          headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
-        });
-        setWizarrAvailability(response.data || { thirdParty: [] });
+        setWizarrAvailability(await loadNavbarIntegrations());
       } catch {
         if (isMounted) {
           setShowWizarrNav(getCachedWizarrNavAvailable());
@@ -279,14 +434,103 @@ export default function Navbar() {
         setWizarrAvailability(event.detail);
         return;
       }
+      clearNavbarIntegrationsCache();
       refreshWizarrAvailability();
     };
 
-    refreshWizarrAvailability();
+    const startupTimer = window.setTimeout(refreshWizarrAvailability, 500);
     window.addEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
     return () => {
       isMounted = false;
       window.removeEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
+      window.clearTimeout(startupTimer);
+    };
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const setTranscodeAvailability = (integrations) => {
+      const nextAvailable = getTdarrAvailabilityFromIntegrations(integrations);
+      localStorage.setItem(TDARR_NAV_AVAILABLE_KEY, String(nextAvailable));
+      if (isMounted) {
+        setShowTdarrNav(nextAvailable);
+        if (!nextAvailable) {
+          setActiveTranscodeCount(0);
+        }
+      }
+      return nextAvailable;
+    };
+
+    const setSafeTranscodeCount = (value) => {
+      const nextCount = Number(value || 0);
+      if (isMounted) {
+        setActiveTranscodeCount(Number.isFinite(nextCount) ? nextCount : 0);
+      }
+    };
+
+    const refreshTranscodeAvailability = async () => {
+      if (!localStorage.getItem("token")) {
+        setTranscodeAvailability({ thirdParty: [] });
+        return false;
+      }
+
+      try {
+        return setTranscodeAvailability(await loadNavbarIntegrations());
+      } catch {
+        if (isMounted) {
+          setShowTdarrNav(getCachedTdarrNavAvailable());
+        }
+        return getCachedTdarrNavAvailable();
+      }
+    };
+
+    const refreshTranscodeCount = async () => {
+      if (!localStorage.getItem("token")) {
+        setTranscodeAvailability({ thirdParty: [] });
+        return;
+      }
+      try {
+        const response = await axios.get("/api/tdarr/transcodes", {
+          headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+        });
+        const nextCount = Number(response.data?.stats?.active || response.data?.active?.length || 0);
+        localStorage.setItem("jellyglance_active_transcode_count", String(nextCount));
+        setSafeTranscodeCount(nextCount);
+      } catch {
+        setSafeTranscodeCount(localStorage.getItem("jellyglance_active_transcode_count"));
+      }
+    };
+
+    const handleTranscodeCount = (event) => setSafeTranscodeCount(event.detail ?? localStorage.getItem("jellyglance_active_transcode_count"));
+    const handleIntegrationsUpdated = (event) => {
+      const hasTdarr = event.detail ? setTranscodeAvailability(event.detail) : getCachedTdarrNavAvailable();
+      if (!event.detail) {
+        clearNavbarIntegrationsCache();
+        refreshTranscodeAvailability();
+      }
+      if (hasTdarr) {
+        refreshTranscodeCount();
+      }
+    };
+
+    const startupTimer = window.setTimeout(() => {
+      refreshTranscodeAvailability().then((hasTdarr) => {
+        if (hasTdarr) refreshTranscodeCount();
+      });
+    }, 650);
+    const intervalId = setInterval(refreshTranscodeCount, 60000);
+    window.addEventListener("jellyglance-transcode-count", handleTranscodeCount);
+    window.addEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
+    window.addEventListener("storage", handleTranscodeCount);
+
+    return () => {
+      isMounted = false;
+      clearInterval(intervalId);
+      window.clearTimeout(startupTimer);
+      window.removeEventListener("jellyglance-transcode-count", handleTranscodeCount);
+      window.removeEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
+      window.removeEventListener("storage", handleTranscodeCount);
     };
   }, []);
 
@@ -315,10 +559,7 @@ export default function Navbar() {
       }
 
       try {
-        const response = await axios.get("/api/integrations", {
-          headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
-        });
-        const nextAvailable = getRequestAvailabilityFromIntegrations(response.data || {});
+        const nextAvailable = getRequestAvailabilityFromIntegrations(await loadNavbarIntegrations());
         localStorage.setItem(REQUEST_NAV_AVAILABLE_KEY, String(nextAvailable));
         if (isMounted) {
           setShowRequestsNav(nextAvailable);
@@ -368,12 +609,16 @@ export default function Navbar() {
         if (!nextAvailable) {
           return;
         }
+      } else {
+        clearNavbarIntegrationsCache();
       }
       refreshRequestCount();
     };
 
-    refreshRequestAvailability();
-    refreshRequestCount();
+    const startupTimer = window.setTimeout(() => {
+      refreshRequestAvailability();
+      refreshRequestCount();
+    }, 650);
     const intervalId = setInterval(refreshRequestCount, 60000);
     window.addEventListener("jellyglance-request-count", handleRequestCount);
     window.addEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
@@ -382,6 +627,7 @@ export default function Navbar() {
     return () => {
       isMounted = false;
       clearInterval(intervalId);
+      window.clearTimeout(startupTimer);
       window.removeEventListener("jellyglance-request-count", handleRequestCount);
       window.removeEventListener("jellyglance-integrations-updated", handleIntegrationsUpdated);
       window.removeEventListener("storage", handleRequestCount);
@@ -431,6 +677,7 @@ export default function Navbar() {
   const getNavBadgeCount = (link) => {
     if (link === "") return activeStreamCount;
     if (link === "downloads") return activeDownloadCount;
+    if (link === "active-transcodes") return activeTranscodeCount;
     if (link === "requests") return requestBadgeCount;
     return 0;
   };
@@ -513,16 +760,29 @@ export default function Navbar() {
         </nav>
       </div>
 
-      <BootstrapNavbar variant="dark" className="desktop-navigation d-flex flex-column py-0 text-center sticky-top" id="primary-navigation">
+      <BootstrapNavbar variant="dark" className={`desktop-navigation d-flex flex-column py-0 text-center sticky-top ${isNavCollapsed ? "is-collapsed" : ""}`} id="primary-navigation">
       <div className="sticky-top py-md-3">
-        <BootstrapNavbar.Brand as={Link} to={"/"} className="d-none d-md-inline">
-          <img src={logo_dark} style={{ height: "52px" }} className="px-2" alt="" />
+        <div className="navbar-brand-row">
+          <BootstrapNavbar.Brand as={Link} to={"/"} className="d-none d-md-inline">
+          <img src={logo_dark} className="navbar-brand-icon px-2" alt="" />
           <img src={projectText} className="navbar-wordmark" alt="JellyGlance" />
         </BootstrapNavbar.Brand>
+        </div>
 
         <Nav className="flex-row flex-md-column w-100">
           {visibleNavData.map((item) => {
             const isActive = isNavItemActive(item, location);
+            const badgeCount =
+              item.link === ""
+                ? activeStreamCount
+                : item.link === "downloads"
+                ? activeDownloadCount
+                : item.link === "active-transcodes"
+                ? activeTranscodeCount
+                : item.link === "requests"
+                ? requestBadgeCount
+                : 0;
+            const navLabel = item.label || (typeof item.text === "string" ? item.text : "");
             return (
               <Nav.Link
                 as={Link}
@@ -530,8 +790,11 @@ export default function Navbar() {
                 className={`navitem${isActive ? " active" : ""} p-2`} // add the "active" class if the link is active
                 to={item.link}
                 onClick={() => setIsMobileNavOpen(false)}
+                title={navLabel}
+                aria-label={navLabel}
               >
                 {item.icon}
+                {badgeCount > 0 ? <span className="nav-icon-badge">{badgeCount}</span> : null}
                 <span className="nav-text">
                   <span>{item.text}</span>
                   {item.link === "" && activeStreamCount > 0 ? (
@@ -544,6 +807,11 @@ export default function Navbar() {
                       {activeDownloadCount}
                     </span>
                   ) : null}
+                  {item.link === "active-transcodes" && activeTranscodeCount > 0 ? (
+                    <span className="nav-live-count" aria-label={`${activeTranscodeCount} active transcodes`}>
+                      {activeTranscodeCount}
+                    </span>
+                  ) : null}
                   {item.link === "requests" && requestBadgeCount > 0 ? (
                     <span className="nav-live-count" aria-label={`${requestBadgeCount} pending or failed requests`}>
                       {requestBadgeCount}
@@ -554,26 +822,33 @@ export default function Navbar() {
             );
           })}
           <div className="navbar-inline-footer">
-            <button className="navitem account-navitem p-2" type="button" onClick={() => setShowAccount(true)}>
-              <span className="account-nav-avatar">
-                {avatarSrc ? (
-                  <img src={avatarSrc} alt="" onError={(event) => (event.currentTarget.style.display = "none")} />
-                ) : (
-                  <AccountCircleLineIcon />
-                )}
-              </span>
-              <span className="account-nav-copy">
-                <strong>{accountName}</strong>
-                <small>{accountRole}</small>
-              </span>
-            </button>
-            <button className="navitem footer-logout p-2" type="button" onClick={handleLogout}>
-              <LogoutBoxLineIcon />
-              <span className="nav-text">
-                <Trans i18nKey="MENU_TABS.LOGOUT" />
-              </span>
-            </button>
-            <VersionCard />
+            <div className="navbar-footer-account-row">
+              <button className="navitem account-navitem p-2" type="button" onClick={() => setShowAccount(true)}>
+                <span className="account-nav-avatar">
+                  {avatarSrc ? (
+                    <img src={avatarSrc} alt="" onError={(event) => (event.currentTarget.style.display = "none")} />
+                  ) : (
+                    <AccountCircleLineIcon />
+                  )}
+                </span>
+                <span className="account-nav-copy">
+                  <strong>{accountName}</strong>
+                  <small>{accountRole}</small>
+                </span>
+              </button>
+              <button
+                type="button"
+                className="navbar-collapse-toggle"
+                onClick={() => setIsNavCollapsed((current) => !current)}
+                aria-label={isNavCollapsed ? "Expand side menu" : "Collapse side menu"}
+                title={isNavCollapsed ? "Expand side menu" : "Collapse side menu"}
+              >
+                {isNavCollapsed ? <ArrowRightSLineIcon size={20} /> : <ArrowLeftSLineIcon size={20} />}
+              </button>
+            </div>
+            <div className="navbar-version-row">
+              <VersionCard />
+            </div>
           </div>
         </Nav>
       </div>
@@ -591,7 +866,7 @@ export default function Navbar() {
             </div>
             <div>
               <strong>{accountName}</strong>
-              <span>{authLabel}</span>
+              <span>{accountRole}</span>
             </div>
           </div>
 
@@ -715,12 +990,14 @@ export default function Navbar() {
           </section>
         </Modal.Body>
         <Modal.Footer>
-          <Button as={Link} to={profilePath} variant="outline-secondary" onClick={() => setShowAccount(false)}>
-            View profile
-          </Button>
-          <Button variant="outline-secondary" onClick={() => setShowAccount(false)}>
-            Close
-          </Button>
+          <div className="profile-modal-secondary-actions">
+            <Button as={Link} to={profilePath} variant="outline-secondary" onClick={() => setShowAccount(false)}>
+              View profile
+            </Button>
+            <Button variant="outline-secondary" onClick={() => setShowAccount(false)}>
+              Close
+            </Button>
+          </div>
           <Button className="profile-logout-button" onClick={handleLogout}>
             Log out
           </Button>

--- a/apps/web/src/pages/components/library/library-card.jsx
+++ b/apps/web/src/pages/components/library/library-card.jsx
@@ -157,6 +157,8 @@ function LibraryCard(props) {
                 className="library-list-image"
                 src={baseUrl + "/proxy/Items/Images/Primary?id=" + props.data.Id + "&fillWidth=320&quality=55"}
                 alt=""
+                loading="lazy"
+                decoding="async"
                 onError={() => setImageLoaded(false)}
               />
             ) : (
@@ -215,7 +217,9 @@ function LibraryCard(props) {
             <Card.Img
               variant="top"
               className="library-card-banner library-card-banner-hover"
-              src={baseUrl + "/proxy/Items/Images/Primary?id=" + props.data.Id + "&fillWidth=800&quality=60"}
+              src={baseUrl + "/proxy/Items/Images/Primary?id=" + props.data.Id + "&fillWidth=560&quality=55"}
+              loading="lazy"
+              decoding="async"
               onError={() => setImageLoaded(false)}
             />
           ) : (

--- a/apps/web/src/pages/components/sessions/session-card.jsx
+++ b/apps/web/src/pages/components/sessions/session-card.jsx
@@ -81,6 +81,7 @@ function SessionCardDetailRow({ label, children, className = "" }) {
 
 function SessionCard(props) {
   const session = props.data.session;
+  const hideIpAddress = Boolean(props.hideIpAddress);
   const nowPlaying = session.NowPlayingItem;
   const playState = session.PlayState;
   const mediaItemId = props.data.session.NowPlayingItem.SeriesId
@@ -239,7 +240,7 @@ function SessionCard(props) {
             <SessionDetailItem label="Viewer" value={session.UserName} />
             <SessionDetailItem label="Device" value={session.DeviceName} />
             <SessionDetailItem label="Client" value={`${session.Client || "Unknown"} ${session.ApplicationVersion || ""}`.trim()} />
-            <SessionDetailItem label="IP address" value={session.RemoteEndPoint} />
+            {!hideIpAddress ? <SessionDetailItem label="IP address" value={session.RemoteEndPoint} /> : null}
             <SessionDetailItem label="Container" value={nowPlaying.ContainerStream} />
             <SessionDetailItem label="Video" value={nowPlaying.VideoStream} wide />
             <SessionDetailItem label="Video bitrate" value={nowPlaying.VideoBitrateStream} />
@@ -391,6 +392,7 @@ function SessionCard(props) {
                       </SessionCardDetailRow>
                     )}
 
+                    {!hideIpAddress ? (
                     <SessionCardDetailRow label={<Trans i18nKey="ACTIVITY_TABLE.IP_ADDRESS" />} className="mt-2">
                         {isRemoteSession(props.data.session.RemoteEndPoint) &&
                         (window.env?.JS_GEOLITE_ACCOUNT_ID ?? import.meta.env.JS_GEOLITE_ACCOUNT_ID) ? (
@@ -404,6 +406,7 @@ function SessionCard(props) {
                           <span>{props.data.session.RemoteEndPoint}</span>
                         )}
                     </SessionCardDetailRow>
+                    ) : null}
 
                     <SessionCardDetailRow label="ETA">
                         {props.data.session.NowPlayingItem.RunTimeTicks ||

--- a/apps/web/src/pages/components/sessions/sessions.jsx
+++ b/apps/web/src/pages/components/sessions/sessions.jsx
@@ -13,9 +13,16 @@ import {
   getCachedActiveSessions,
   subscribeActiveSessions,
 } from "../../../lib/session-cache";
+import {
+  ACTIVE_SESSION_IP_PRIVACY_EVENT,
+  ACTIVE_SESSION_IP_PRIVACY_KEY,
+  getActiveSessionIpPrivacy,
+  shouldHideActiveSessionIp,
+} from "../../../lib/privacy-settings";
 
-function Sessions() {
+function Sessions({ surface = "home" }) {
   const [data, setData] = useState(() => getCachedActiveSessions());
+  const [ipPrivacy, setIpPrivacy] = useState(() => getActiveSessionIpPrivacy());
   const [config, setConfig] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem("config") || "null");
@@ -23,6 +30,23 @@ function Sessions() {
       return null;
     }
   });
+
+  useEffect(() => {
+    const handleIpPrivacyUpdate = () => setIpPrivacy(getActiveSessionIpPrivacy());
+    const handleStorage = (event) => {
+      if (event.key === ACTIVE_SESSION_IP_PRIVACY_KEY) {
+        handleIpPrivacyUpdate();
+      }
+    };
+
+    window.addEventListener(ACTIVE_SESSION_IP_PRIVACY_EVENT, handleIpPrivacyUpdate);
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener(ACTIVE_SESSION_IP_PRIVACY_EVENT, handleIpPrivacyUpdate);
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
 
   useEffect(() => {
     const unsubscribe = subscribeActiveSessions(setData);
@@ -42,6 +66,8 @@ function Sessions() {
     };
   }, []);
 
+  const hideIpAddress = shouldHideActiveSessionIp(surface, ipPrivacy);
+
   useEffect(() => {
     const fetchConfig = async () => {
       try {
@@ -59,7 +85,7 @@ function Sessions() {
 
   if (!config && !data) {
     return (
-      <div>
+      <div className="sessions-widget sessions-widget-loading">
         <h1 className="my-3">
           Active Sessions
         </h1>
@@ -73,7 +99,7 @@ function Sessions() {
 
   if ((!data && config) || data.length === 0) {
     return (
-      <div>
+      <div className="sessions-widget sessions-widget-empty">
         <h1 className="my-3">
           Active Sessions
         </h1>
@@ -85,7 +111,7 @@ function Sessions() {
   }
 
   return (
-    <div>
+    <div className="sessions-widget">
       <h1 className="my-3">
         Active Sessions
       </h1>
@@ -96,7 +122,7 @@ function Sessions() {
             .sort((a, b) => a.Id.padStart(12, "0").localeCompare(b.Id.padStart(12, "0")))
             .map((session) => (
               <ErrorBoundary key={session.Id}>
-                <SessionCard data={{ session: session, base_url: config?.base_url }} />
+                <SessionCard data={{ session: session, base_url: config?.base_url }} hideIpAddress={hideIpAddress} />
               </ErrorBoundary>
             ))}
       </div>

--- a/apps/web/src/pages/components/settings/KioskSettings.jsx
+++ b/apps/web/src/pages/components/settings/KioskSettings.jsx
@@ -1,0 +1,221 @@
+import { useState } from "react";
+import Button from "react-bootstrap/Button";
+import ExternalLinkLineIcon from "remixicon-react/ExternalLinkLineIcon";
+import EyeLineIcon from "remixicon-react/EyeLineIcon";
+import EyeOffLineIcon from "remixicon-react/EyeOffLineIcon";
+import RestartLineIcon from "remixicon-react/RestartLineIcon";
+import {
+  DEFAULT_HOME_ORDER,
+  HOME_PRESETS,
+  HOME_SECTION_DEFINITIONS,
+  HOME_WIDGET_SIZE_LABELS,
+  loadHomeSettings,
+  normalizeHomeOrder,
+  saveHomeSettings,
+} from "../../../lib/home-settings";
+
+const KIOSK_SCOPE = "kiosk";
+
+export default function KioskSettings() {
+  const [settings, setSettings] = useState(() => loadHomeSettings(KIOSK_SCOPE));
+  const sectionLabels = HOME_SECTION_DEFINITIONS.reduce((labels, section) => ({ ...labels, [section.id]: section.label }), {});
+
+  function updateSettings(updater) {
+    const nextSettings = saveHomeSettings(typeof updater === "function" ? updater(settings) : { ...settings, ...updater }, KIOSK_SCOPE);
+    setSettings(nextSettings);
+  }
+
+  function applyPreset(presetId) {
+    const preset = HOME_PRESETS[presetId];
+    if (!preset) return;
+    updateSettings((current) => ({
+      ...current,
+      order: preset.order,
+      hidden: preset.hidden,
+      density: preset.density,
+      sizes: preset.sizes || {},
+      preset: presetId,
+    }));
+  }
+
+  function resetKiosk() {
+    const preset = HOME_PRESETS.kiosk;
+    updateSettings({
+      ...preset,
+      title: "JellyGlance Kiosk",
+      autoRotate: false,
+      theme: "default",
+      pinned: "",
+      alertRules: { backupDays: 7, requestThreshold: 1, missingPosterThreshold: 1 },
+      preset: "kiosk",
+      sizes: preset.sizes || {},
+    });
+  }
+
+  function toggleSection(sectionId) {
+    updateSettings((current) => {
+      const hidden = new Set(current.hidden || []);
+      if (hidden.has(sectionId)) {
+        hidden.delete(sectionId);
+      } else {
+        hidden.add(sectionId);
+      }
+      return { ...current, hidden: [...hidden], preset: "custom" };
+    });
+  }
+
+  function updateWidgetSize(sectionId, size) {
+    updateSettings((current) => ({
+      ...current,
+      sizes: { ...(current.sizes || {}), [sectionId]: size },
+      preset: "custom",
+    }));
+  }
+
+  function moveSection(sectionId, direction) {
+    updateSettings((current) => {
+      const nextOrder = normalizeHomeOrder(current.order);
+      const index = nextOrder.indexOf(sectionId);
+      const nextIndex = index + direction;
+      if (index < 0 || nextIndex < 0 || nextIndex >= nextOrder.length) return current;
+      [nextOrder[index], nextOrder[nextIndex]] = [nextOrder[nextIndex], nextOrder[index]];
+      return { ...current, order: nextOrder, preset: "custom" };
+    });
+  }
+
+  const orderedSections = normalizeHomeOrder(settings.order);
+  const visibleSections = orderedSections.filter((sectionId) => !settings.hidden.includes(sectionId));
+  const hiddenSections = orderedSections.filter((sectionId) => settings.hidden.includes(sectionId));
+
+  function renderWidgetRow(sectionId, index, sourceSections) {
+    const isHidden = settings.hidden.includes(sectionId);
+    const orderIndex = orderedSections.indexOf(sectionId);
+
+    return (
+      <article key={sectionId} className={isHidden ? "is-hidden" : ""}>
+        <span className="kiosk-widget-order">{isHidden ? "Hidden" : index + 1}</span>
+        <button type="button" title={isHidden ? "Show widget" : "Hide widget"} onClick={() => toggleSection(sectionId)}>
+          {isHidden ? <EyeOffLineIcon size={18} /> : <EyeLineIcon size={18} />}
+        </button>
+        <strong>{sectionLabels[sectionId] || sectionId}</strong>
+        <select value={settings.sizes?.[sectionId] || "medium"} onChange={(event) => updateWidgetSize(sectionId, event.target.value)}>
+          {Object.entries(HOME_WIDGET_SIZE_LABELS).map(([sizeId, label]) => (
+            <option key={sizeId} value={sizeId}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <div>
+          <button type="button" disabled={orderIndex === 0 || sourceSections.length < 2} onClick={() => moveSection(sectionId, -1)}>
+            Up
+          </button>
+          <button type="button" disabled={orderIndex === DEFAULT_HOME_ORDER.length - 1 || sourceSections.length < 2} onClick={() => moveSection(sectionId, 1)}>
+            Down
+          </button>
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <div className="kiosk-settings-page">
+      <header className="kiosk-settings-hero">
+        <div>
+          <span>Kiosk display</span>
+          <h2>Customise Kiosk Page</h2>
+          <p>Control the title, density, theme, visible widgets, widget sizes, and order used by the static kiosk view.</p>
+        </div>
+        <div className="kiosk-settings-actions">
+          <Button as="a" href="/home/kiosk" target="_blank" rel="noreferrer" variant="outline-primary">
+            <ExternalLinkLineIcon size={16} />
+            Open kiosk
+          </Button>
+          <Button type="button" variant="outline-secondary" onClick={resetKiosk}>
+            <RestartLineIcon size={16} />
+            Reset
+          </Button>
+        </div>
+      </header>
+
+      <section className="kiosk-settings-panel">
+        <div className="kiosk-settings-grid">
+          <label>
+            <span>Title</span>
+            <input value={settings.title} placeholder="JellyGlance Kiosk" onChange={(event) => updateSettings({ title: event.target.value, preset: "custom" })} />
+          </label>
+          <label>
+            <span>Preset</span>
+            <select value={settings.preset} onChange={(event) => applyPreset(event.target.value)}>
+              <option value="custom">Custom</option>
+              {Object.entries(HOME_PRESETS).map(([presetId, preset]) => (
+                <option key={presetId} value={presetId}>
+                  {preset.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>Pinned widget</span>
+            <select value={settings.pinned} onChange={(event) => updateSettings({ pinned: event.target.value, preset: "custom" })}>
+              <option value="">None</option>
+              {HOME_SECTION_DEFINITIONS.map((section) => (
+                <option key={section.id} value={section.id}>
+                  {section.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>Density</span>
+            <select value={settings.density} onChange={(event) => updateSettings({ density: event.target.value, preset: "custom" })}>
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </label>
+          <label>
+            <span>Theme</span>
+            <select value={settings.theme} onChange={(event) => updateSettings({ theme: event.target.value, preset: "custom" })}>
+              <option value="default">Default</option>
+              <option value="darker">Darker</option>
+              <option value="neon">Neon</option>
+              <option value="highContrast">High contrast</option>
+              <option value="wall">Wall display</option>
+            </select>
+          </label>
+          <label className="kiosk-settings-toggle">
+            <span>Refresh</span>
+            <button type="button" className="is-enabled" disabled>
+              Every 5 minutes
+            </button>
+          </label>
+        </div>
+      </section>
+
+      <section className="kiosk-settings-panel">
+        <div className="kiosk-widget-heading">
+          <div>
+            <span>Widgets</span>
+            <h3>Order and visibility</h3>
+          </div>
+          <small>{orderedSections.length - settings.hidden.length} visible</small>
+        </div>
+
+        <div className="kiosk-widget-groups">
+          <div className="kiosk-widget-group">
+            <h4>Enabled order</h4>
+            <div className="kiosk-widget-list">
+              {visibleSections.length ? visibleSections.map((sectionId, index) => renderWidgetRow(sectionId, index, visibleSections)) : <p className="kiosk-widget-empty">No widgets enabled.</p>}
+            </div>
+          </div>
+
+          <div className="kiosk-widget-group">
+            <h4>Hidden widgets</h4>
+            <div className="kiosk-widget-list">
+              {hiddenSections.length ? hiddenSections.map((sectionId, index) => renderWidgetRow(sectionId, index, hiddenSections)) : <p className="kiosk-widget-empty">No hidden widgets.</p>}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/pages/components/settings/security.jsx
+++ b/apps/web/src/pages/components/settings/security.jsx
@@ -14,6 +14,11 @@ import UserSettingsLineIcon from "remixicon-react/UserSettingsLineIcon";
 import { Link } from "react-router-dom";
 
 import Config from "../../../lib/config";
+import {
+  ACTIVE_SESSION_IP_PRIVACY_OPTIONS,
+  getActiveSessionIpPrivacy,
+  setActiveSessionIpPrivacy,
+} from "../../../lib/privacy-settings";
 
 import "../../css/settings/settings.css";
 import { InputGroup } from "react-bootstrap";
@@ -43,10 +48,13 @@ export default function SecuritySettings() {
   const [authMode, setAuthMode] = useState("quick-connect");
   const [showOidcSecret, setShowOidcSecret] = useState(false);
   const [oidcValues, setOidcValues] = useState({});
+  const [activeSessionIpPrivacy, setActiveSessionIpPrivacyState] = useState(() => getActiveSessionIpPrivacy());
   const [saving, setSaving] = useState(false);
   const [isSubmitted, setisSubmitted] = useState("");
   const [submissionMessage, setsubmissionMessage] = useState("");
   const token = localStorage.getItem("token");
+  const activeAuthMode = authModes.find((mode) => mode.id === authMode) || authModes[0];
+  const activePrivacyMode = ACTIVE_SESSION_IP_PRIVACY_OPTIONS.find((option) => option.id === activeSessionIpPrivacy) || ACTIVE_SESSION_IP_PRIVACY_OPTIONS[0];
 
   useEffect(() => {
     const fetchConfig = async () => {
@@ -125,9 +133,67 @@ export default function SecuritySettings() {
     setOidcValues({ ...oidcValues, [event.target.name]: event.target.value });
   }
 
+  function handleActiveSessionIpPrivacyChange(value) {
+    const nextValue = setActiveSessionIpPrivacy(value);
+    setActiveSessionIpPrivacyState(nextValue);
+    setisSubmitted("Success");
+    setsubmissionMessage("Active Sessions IP privacy updated.");
+  }
+
   return (
-    <div>
-      <h1>Security</h1>
+    <div className="security-page">
+      <header className="security-hero">
+        <div>
+          <span>Access Control</span>
+          <h1>Security</h1>
+          <p>Manage sign-in, identity providers, and what sensitive session details are visible on shared screens.</p>
+        </div>
+        <div className="security-current-stack" aria-label="Current security settings">
+          <article>
+            <LoginCircleLineIcon size={18} />
+            <span>Authentication</span>
+            <strong>{activeAuthMode.title}</strong>
+          </article>
+          <article>
+            <ShieldKeyholeLineIcon size={18} />
+            <span>IP Privacy</span>
+            <strong>{activePrivacyMode.title}</strong>
+          </article>
+        </div>
+      </header>
+
+      {isSubmitted !== "" ? (
+        <Alert bg="dark" data-bs-theme="dark" variant={isSubmitted === "Failed" ? "danger" : "success"} className="security-status-alert">
+          {submissionMessage}
+        </Alert>
+      ) : null}
+
+      <section className="settings-form security-auth-form security-privacy-form">
+        <div className="security-auth-header">
+          <div>
+            <h2>Active Sessions privacy</h2>
+            <p>Choose where JellyGlance hides viewer IP addresses in Active Sessions cards and details.</p>
+          </div>
+          <strong>{activePrivacyMode.title}</strong>
+        </div>
+
+        <div className="security-auth-grid security-privacy-grid" role="radiogroup" aria-label="Active Sessions IP privacy">
+          {ACTIVE_SESSION_IP_PRIVACY_OPTIONS.map(({ id, title, text }) => (
+            <button
+              key={id}
+              type="button"
+              className={`security-auth-card ${activeSessionIpPrivacy === id ? "is-active" : ""}`}
+              onClick={() => handleActiveSessionIpPrivacyChange(id)}
+            >
+              <ShieldKeyholeLineIcon size={22} />
+              <span>
+                <strong>{title}</strong>
+                <small>{text}</small>
+              </span>
+            </button>
+          ))}
+        </div>
+      </section>
 
       <Form onSubmit={handleAuthSubmit} className="settings-form security-auth-form">
         <div className="security-auth-header">
@@ -135,7 +201,7 @@ export default function SecuritySettings() {
             <h2>Authentication</h2>
             <p>Choose how JellyGlance signs users in after Jellyfin setup.</p>
           </div>
-          <strong>{authModes.find((mode) => mode.id === authMode)?.title}</strong>
+          <strong>{activeAuthMode.title}</strong>
         </div>
 
         <div className="security-auth-grid" role="radiogroup" aria-label="Authentication mode">
@@ -227,19 +293,7 @@ export default function SecuritySettings() {
           </div>
         )}
 
-        {isSubmitted !== "" ? (
-          isSubmitted === "Failed" ? (
-            <Alert bg="dark" data-bs-theme="dark" variant="danger">
-              {submissionMessage}
-            </Alert>
-          ) : (
-            <Alert bg="dark" data-bs-theme="dark" variant="success">
-              {submissionMessage}
-            </Alert>
-          )
-        ) : null}
-
-        <div className="d-flex flex-column flex-md-row justify-content-end align-items-md-center">
+        <div className="security-form-actions">
           <Button variant="outline-success" type="submit" disabled={saving}>
             {saving ? <Spinner animation="border" size="sm" /> : authMode === "oidc" ? "Test & Save" : "Save Authentication"}
           </Button>

--- a/apps/web/src/pages/components/settings/settingsConfig.jsx
+++ b/apps/web/src/pages/components/settings/settingsConfig.jsx
@@ -7,13 +7,208 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Button from "react-bootstrap/Button";
 import Alert from "react-bootstrap/Alert";
-import ToggleButton from "react-bootstrap/ToggleButton";
-import ToggleButtonGroup from "react-bootstrap/ToggleButtonGroup";
-import Dropdown from "react-bootstrap/Dropdown";
+import ArrowDownSLineIcon from "remixicon-react/ArrowDownSLineIcon";
+import ArrowUpSLineIcon from "remixicon-react/ArrowUpSLineIcon";
+import DragMove2LineIcon from "remixicon-react/DragMove2LineIcon";
+import EyeLineIcon from "remixicon-react/EyeLineIcon";
+import EyeOffLineIcon from "remixicon-react/EyeOffLineIcon";
+import ExternalLinkLineIcon from "remixicon-react/ExternalLinkLineIcon";
+import LockLineIcon from "remixicon-react/LockLineIcon";
 
 import "../../css/settings/settings.css";
 import { Trans } from "react-i18next";
+import { FONT_WEIGHT_OPTIONS, getStoredFontWeight, saveFontWeightPreference } from "../../../lib/appearance";
 import { languages } from "../../../lib/languages";
+import { navData } from "../../../lib/navdata";
+import { DEFAULT_THEME, THEME_PRESETS, getStoredTheme, resetTheme, saveTheme } from "../../../lib/theme";
+import {
+  applyNavOrder,
+  getStoredHiddenNavLinks,
+  getStoredNavOrder,
+  LOCKED_NAV_LINKS,
+  resetHiddenNavLinks,
+  resetNavOrder,
+  saveHiddenNavLinks,
+  saveNavOrder,
+} from "../../../lib/nav-order";
+
+function getNavLabel(item) {
+  if (typeof item.text === "string") return item.text;
+  if (item.link === "") return "Home";
+  return item.link
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+const THEME_COLOR_FIELDS = [
+  { key: "primary", label: "Primary" },
+  { key: "secondary", label: "Secondary" },
+  { key: "background", label: "Background" },
+  { key: "surface", label: "Surface" },
+];
+const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
+
+function NavigationOrderSettings() {
+  const [navOrder, setNavOrder] = useState(() => getStoredNavOrder(navData));
+  const [hiddenLinks, setHiddenLinks] = useState(() => getStoredHiddenNavLinks(navData));
+  const [draggedLink, setDraggedLink] = useState("");
+  const orderedItems = applyNavOrder(navData, navOrder);
+  const lockedItems = orderedItems.filter((item) => LOCKED_NAV_LINKS.has(item.link));
+  const reorderableItems = orderedItems.filter((item) => !LOCKED_NAV_LINKS.has(item.link));
+
+  function commitOrder(nextOrder) {
+    setNavOrder(saveNavOrder(nextOrder, navData));
+  }
+
+  function moveLink(link, direction) {
+    const currentIndex = navOrder.indexOf(link);
+    const targetIndex = currentIndex + direction;
+    if (currentIndex < 0 || targetIndex < 0 || targetIndex >= navOrder.length) return;
+    const nextOrder = [...navOrder];
+    const [movedLink] = nextOrder.splice(currentIndex, 1);
+    nextOrder.splice(targetIndex, 0, movedLink);
+    commitOrder(nextOrder);
+  }
+
+  function moveDraggedLink(targetLink) {
+    if (!draggedLink || draggedLink === targetLink) return;
+    const nextOrder = navOrder.filter((link) => link !== draggedLink);
+    const targetIndex = nextOrder.indexOf(targetLink);
+    nextOrder.splice(targetIndex < 0 ? nextOrder.length : targetIndex, 0, draggedLink);
+    commitOrder(nextOrder);
+  }
+
+  function handleReset() {
+    resetNavOrder();
+    resetHiddenNavLinks();
+    setNavOrder(getStoredNavOrder(navData));
+    setHiddenLinks(getStoredHiddenNavLinks(navData));
+  }
+
+  function toggleHidden(link) {
+    const nextHiddenLinks = hiddenLinks.includes(link) ? hiddenLinks.filter((hiddenLink) => hiddenLink !== link) : [...hiddenLinks, link];
+    setHiddenLinks(saveHiddenNavLinks(nextHiddenLinks, navData));
+  }
+
+  return (
+    <section className="settings-form nav-order-settings" aria-labelledby="nav-order-heading">
+      <div className="nav-order-header">
+        <div>
+          <h2 id="nav-order-heading">Navbar order</h2>
+          <p>Drag the unlocked items into the order you want. Home, Settings, and About stay fixed.</p>
+        </div>
+        <Button type="button" variant="outline-secondary" onClick={handleReset}>
+          Reset
+        </Button>
+      </div>
+
+      <div className="nav-order-locked" aria-label="Locked navigation items">
+        {lockedItems.map((item) => (
+          <span key={item.link || "home"}>
+            <LockLineIcon size={14} />
+            {getNavLabel(item)}
+          </span>
+        ))}
+      </div>
+
+      <div className="nav-order-list">
+        {reorderableItems.map((item, index) => {
+          const isHidden = hiddenLinks.includes(item.link);
+          const label = getNavLabel(item);
+
+          return (
+            <div
+              key={item.link}
+              className={`nav-order-row${draggedLink === item.link ? " is-dragging" : ""}${isHidden ? " is-hidden" : ""}`}
+              draggable
+              onDragStart={(event) => {
+                setDraggedLink(item.link);
+                event.dataTransfer.effectAllowed = "move";
+                event.dataTransfer.setData("text/plain", item.link);
+              }}
+              onDragOver={(event) => {
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "move";
+              }}
+              onDrop={(event) => {
+                event.preventDefault();
+                moveDraggedLink(item.link);
+                setDraggedLink("");
+              }}
+              onDragEnd={() => setDraggedLink("")}
+            >
+              <span className="nav-order-drag" aria-hidden="true">
+                <DragMove2LineIcon size={18} />
+              </span>
+              <span className="nav-order-icon">{item.icon}</span>
+              <strong>{label}</strong>
+              <button
+                type="button"
+                className="nav-order-visibility"
+                onClick={() => toggleHidden(item.link)}
+                aria-pressed={!isHidden}
+                aria-label={isHidden ? `Show ${label} in navbar` : `Hide ${label} from navbar`}
+                title={isHidden ? "Show tab" : "Hide tab"}
+              >
+                {isHidden ? <EyeOffLineIcon size={18} /> : <EyeLineIcon size={18} />}
+              </button>
+              <div className="nav-order-actions">
+                <button type="button" onClick={() => moveLink(item.link, -1)} disabled={index === 0} aria-label={`Move ${label} up`}>
+                  <ArrowUpSLineIcon size={18} />
+                </button>
+                <button type="button" onClick={() => moveLink(item.link, 1)} disabled={index === reorderableItems.length - 1} aria-label={`Move ${label} down`}>
+                  <ArrowDownSLineIcon size={18} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function ThemePresetPreview({ label, theme }) {
+  return (
+    <div
+      className="general-theme-preview"
+      style={{
+        "--preview-primary": theme.primary,
+        "--preview-secondary": theme.secondary,
+        "--preview-background": theme.background,
+        "--preview-surface": theme.surface,
+      }}
+    >
+      <div className="general-theme-preview-sidebar">
+        <span />
+        <i />
+        <i />
+        <i />
+      </div>
+      <div className="general-theme-preview-main">
+        <div className="general-theme-preview-top">
+          <strong>{label}</strong>
+          <span>Live preview</span>
+        </div>
+        <div className="general-theme-preview-card">
+          <div>
+            <b>Active Sessions</b>
+            <small>2 streams running</small>
+          </div>
+          <button type="button" tabIndex={-1}>
+            Sync
+          </button>
+        </div>
+        <div className="general-theme-preview-list">
+          <span />
+          <span />
+          <span />
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function SettingsConfig() {
   const [config, setConfig] = useState(null);
@@ -24,6 +219,9 @@ export default function SettingsConfig() {
   const [submissionMessage, setsubmissionMessage] = useState("");
   const [submissionMessageExternal, setsubmissionMessageExternal] = useState("");
   const [twelve_hr, set12hr] = useState(localStorage.getItem("12hr") === "true");
+  const [fontWeight, setFontWeight] = useState(() => getStoredFontWeight());
+  const [theme, setTheme] = useState(() => getStoredTheme());
+  const [themeDraft, setThemeDraft] = useState(() => getStoredTheme());
 
   const storage_12hr = localStorage.getItem("12hr");
 
@@ -50,6 +248,7 @@ export default function SettingsConfig() {
 
   async function handleFormSubmitExternal(event) {
     event.preventDefault();
+    setTheme(saveTheme(themeDraft));
 
     setisSubmittedExternal("");
     axios
@@ -78,7 +277,7 @@ export default function SettingsConfig() {
   }
 
   function updateLanguage(event) {
-    const languageCode = event.target.getAttribute("value");
+    const languageCode = event.target.value;
     setSelectedLanguage(languageCode);
     localStorage.setItem("i18nextLng", languageCode);
   }
@@ -96,101 +295,187 @@ export default function SettingsConfig() {
     localStorage.setItem("12hr", is_12_hr);
   }
 
+  function updateFontWeight(nextFontWeight) {
+    setFontWeight(saveFontWeightPreference(nextFontWeight));
+  }
+
+  function updateThemePreset(presetName) {
+    if (presetName === "custom") return;
+    const preset = THEME_PRESETS.find((item) => item.name === presetName);
+    if (!preset) return;
+    setThemeDraft(preset);
+  }
+
+  function updateThemeDraftColor(key, value) {
+    if (!HEX_COLOR_PATTERN.test(value)) return;
+    setThemeDraft((currentTheme) => ({
+      ...currentTheme,
+      [key]: value,
+    }));
+  }
+
+  function restoreTheme() {
+    const restoredTheme = resetTheme();
+    setTheme(restoredTheme);
+    setThemeDraft(restoredTheme);
+  }
+
+  const activeThemePreset = THEME_PRESETS.find(
+    (preset) =>
+      themeDraft.primary === preset.primary &&
+      themeDraft.secondary === preset.secondary &&
+      themeDraft.background === preset.background &&
+      themeDraft.surface === preset.surface
+  );
+  const externalUrl = formValuesExternal.ExternalUrl || "";
+  const selectedThemeName = activeThemePreset?.name || "custom";
+  const previewTheme = activeThemePreset || themeDraft;
+  const previewThemeName = activeThemePreset?.name || "Custom";
+  const hasThemeChanges = JSON.stringify(themeDraft) !== JSON.stringify(theme);
+
   return (
-    <div>
-      <h1>
-        <Trans i18nKey={"SETTINGS_PAGE.SETTINGS"} />
-      </h1>
-      <Form onSubmit={handleFormSubmitExternal} className="settings-form">
-        <Form.Group as={Row} className="mb-3">
-          <Form.Label column className="">
-            <Trans i18nKey={"SETTINGS_PAGE.EXTERNAL_URL"} />
-          </Form.Label>
-          <Col sm="10">
-            <Form.Control
-              id="ExternalUrl"
-              name="ExternalUrl"
-              value={formValuesExternal.ExternalUrl || ""}
-              onChange={handleFormChangeExternal}
-              placeholder="http://example.jellyfin.server"
-            />
-          </Col>
-        </Form.Group>
+    <div className="general-settings-page">
+      <div className="general-settings-content">
+        <Form onSubmit={handleFormSubmitExternal} className="settings-form general-settings-card is-single-form">
+          <div className="general-settings-card-head">
+            <div>
+              <h3>Core preferences</h3>
+              <p>Set server access, display behaviour, theme, language, and navigation layout.</p>
+            </div>
+            <ExternalLinkLineIcon />
+          </div>
+          <div className="general-form-section">
+            <h4>Server access</h4>
+            <Form.Group as={Row} className="mb-3">
+              <Form.Label column>
+                <Trans i18nKey={"SETTINGS_PAGE.EXTERNAL_URL"} />
+              </Form.Label>
+              <Col sm="10">
+                <Form.Control id="ExternalUrl" name="ExternalUrl" value={externalUrl} onChange={handleFormChangeExternal} placeholder="https://jellyglance.example.com" />
+              </Col>
+            </Form.Group>
+          </div>
 
-        {isSubmittedExternal !== "" ? (
-          isSubmittedExternal === "Failed" ? (
-            <Alert bg="dark" data-bs-theme="dark" variant="danger">
+          {isSubmittedExternal !== "" ? (
+            <Alert bg="dark" data-bs-theme="dark" variant={isSubmittedExternal === "Failed" ? "danger" : "success"}>
               {submissionMessageExternal}
             </Alert>
-          ) : (
-            <Alert bg="dark" data-bs-theme="dark" variant="success">
-              {submissionMessageExternal}
-            </Alert>
-          )
-        ) : (
-          <></>
-        )}
-        <div className="d-flex flex-column flex-md-row justify-content-end align-items-md-center">
-          <Button variant="outline-success" type="submit">
-            <Trans i18nKey={"SETTINGS_PAGE.UPDATE"} />
-          </Button>
-        </div>
-      </Form>
-
-      <Form className="settings-form">
-        <Form.Group as={Row} className="mb-3">
-          <Form.Label column className="">
-            <Trans i18nKey={"SETTINGS_PAGE.HOUR_FORMAT"} />
-          </Form.Label>
-          <Col>
-            <ToggleButtonGroup type="checkbox" className="d-flex">
-              <ToggleButton
-                variant="outline-primary"
-                active={twelve_hr}
-                onClick={() => {
-                  toggle12Hr(true);
-                }}
-              >
-                <Trans i18nKey={"SETTINGS_PAGE.HOUR_FORMAT_12"} />
-              </ToggleButton>
-              <ToggleButton
-                variant="outline-primary"
-                active={!twelve_hr}
-                onClick={() => {
-                  toggle12Hr(false);
-                }}
-              >
-                <Trans i18nKey={"SETTINGS_PAGE.HOUR_FORMAT_24"} />
-              </ToggleButton>
-            </ToggleButtonGroup>
-          </Col>
-        </Form.Group>
-      </Form>
-      <Form className="settings-form">
-        <Form.Group as={Row} className="mb-3">
-          <Form.Label column className="">
-            <Trans i18nKey={"SETTINGS_PAGE.LANGUAGE"} />
-          </Form.Label>
-          <Col>
-            <Dropdown className="w-100">
-              <Dropdown.Toggle variant="outline-primary" className="w-100 dropdown-basic">
-                {languages.find((language) => language.id === selectedLanguage)?.description || "English"}
-              </Dropdown.Toggle>
-
-              <Dropdown.Menu className="w-100">
-                {languages &&
-                  languages
-                    .sort((a, b) => a.description - b.description)
+          ) : null}
+          <div className="general-form-section">
+            <h4>Display preferences</h4>
+            <Form.Group as={Row} className="mb-3">
+              <Form.Label column>
+                <Trans i18nKey={"SETTINGS_PAGE.HOUR_FORMAT"} />
+              </Form.Label>
+              <Col sm="10">
+                <Form.Select value={twelve_hr ? "12" : "24"} onChange={(event) => toggle12Hr(event.target.value === "12")}>
+                  <option value="24">
+                    <Trans i18nKey={"SETTINGS_PAGE.HOUR_FORMAT_24"} />
+                  </option>
+                  <option value="12">
+                    <Trans i18nKey={"SETTINGS_PAGE.HOUR_FORMAT_12"} />
+                  </option>
+                </Form.Select>
+              </Col>
+            </Form.Group>
+            <Form.Group as={Row} className="mb-3">
+              <Form.Label column>
+                <Trans i18nKey={"SETTINGS_PAGE.LANGUAGE"} />
+              </Form.Label>
+              <Col sm="10">
+                <Form.Select value={selectedLanguage} onChange={updateLanguage}>
+                  {languages
+                    .slice()
+                    .sort((a, b) => a.description.localeCompare(b.description))
                     .map((language) => (
-                      <Dropdown.Item onClick={updateLanguage} value={language.id} key={language.id}>
+                      <option value={language.id} key={language.id}>
                         {language.description}
-                      </Dropdown.Item>
+                      </option>
                     ))}
-              </Dropdown.Menu>
-            </Dropdown>
-          </Col>
-        </Form.Group>
-      </Form>
+                </Form.Select>
+              </Col>
+            </Form.Group>
+            <Form.Group as={Row} className="mb-0">
+              <Form.Label column>Font weight</Form.Label>
+              <Col sm="10">
+                <Form.Select value={fontWeight} onChange={(event) => updateFontWeight(event.target.value)}>
+                  {FONT_WEIGHT_OPTIONS.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Col>
+            </Form.Group>
+          </div>
+          <div className="general-form-section">
+            <h4>Theme preset</h4>
+            <Form.Group as={Row} className="mb-3">
+              <Form.Label column>Theme</Form.Label>
+              <Col sm="10">
+                <Form.Select value={selectedThemeName} onChange={(event) => updateThemePreset(event.target.value)}>
+                  <option value="custom">Custom</option>
+                  {THEME_PRESETS.map((preset) => (
+                    <option key={preset.name} value={preset.name}>
+                      {preset.name}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Col>
+            </Form.Group>
+            <div className="general-theme-selected">
+              <div>
+                <span className="general-theme-swatches" aria-hidden="true">
+                  <i style={{ backgroundColor: previewTheme.primary }} />
+                  <i style={{ backgroundColor: previewTheme.secondary }} />
+                  <i style={{ backgroundColor: previewTheme.background }} />
+                  <i style={{ backgroundColor: previewTheme.surface }} />
+                </span>
+                <strong>{previewThemeName}</strong>
+              </div>
+              <div className="general-theme-custom-grid">
+                {THEME_COLOR_FIELDS.map((field) => (
+                  <label key={field.key} className="general-theme-custom-control">
+                    <span>{field.label}</span>
+                    <div>
+                      <input
+                        type="color"
+                        value={themeDraft[field.key]}
+                        onChange={(event) => updateThemeDraftColor(field.key, event.target.value)}
+                        aria-label={`${field.label} colour`}
+                      />
+                      <input
+                        type="text"
+                        value={themeDraft[field.key]}
+                        onChange={(event) => updateThemeDraftColor(field.key, event.target.value)}
+                        aria-label={`${field.label} hex colour`}
+                        maxLength={7}
+                      />
+                    </div>
+                  </label>
+                ))}
+              </div>
+              <ThemePresetPreview label={previewThemeName} theme={previewTheme} />
+            </div>
+          </div>
+          <div className="general-settings-actions">
+            <Button variant="outline-success" type="submit">
+              <Trans i18nKey={"SETTINGS_PAGE.UPDATE"} />
+            </Button>
+            <Button
+              variant="outline-secondary"
+              type="button"
+              onClick={restoreTheme}
+              disabled={JSON.stringify(theme) === JSON.stringify(DEFAULT_THEME) && JSON.stringify(themeDraft) === JSON.stringify(DEFAULT_THEME)}
+            >
+              Reset theme
+            </Button>
+            {hasThemeChanges ? <span className="general-settings-pending">Theme preview not applied</span> : null}
+          </div>
+        </Form>
+
+        <NavigationOrderSettings />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/pages/components/statCards/ItemStatComponent.jsx
+++ b/apps/web/src/pages/components/statCards/ItemStatComponent.jsx
@@ -34,6 +34,8 @@ function ItemStatComponent(props) {
   }
 
   const renderItemName = (item) => {
+    const mediaItemId = item.Id || item.ItemId || item.NowPlayingItemId || item.jellyglanceItemId;
+
     if (item.UserId) {
       return (
         <Link to={`/users/${item.UserId}`} className="item-name">
@@ -45,12 +47,16 @@ function ItemStatComponent(props) {
     }
 
     if (!item.Client && !props.icon) {
-      return (
-        <Link to={`/libraries/item/${item.Id}`} className="item-name">
+      return mediaItemId ? (
+        <Link to={`/libraries/item/${mediaItemId}`} className="item-name">
           <Tooltip title={item.Name}>
             <span className="item-text">{item.Name}</span>
           </Tooltip>
         </Link>
+      ) : (
+        <Tooltip title={item.Name}>
+          <span className="item-text">{item.Name}</span>
+        </Tooltip>
       );
     }
 

--- a/apps/web/src/pages/components/statCards/most_active_users.jsx
+++ b/apps/web/src/pages/components/statCards/most_active_users.jsx
@@ -76,6 +76,8 @@ function MostActiveUsers(props) {
       width="100%" 
       style={{borderRadius:'50%'}}
       alt=""
+      loading="lazy"
+      decoding="async"
       onError={()=>setLoaded(false)}
       />
     );

--- a/apps/web/src/pages/css/about.css
+++ b/apps/web/src/pages/css/about.css
@@ -391,13 +391,20 @@
 }
 
 .about-install,
-.about-links {
+.about-links,
+.about-contributors {
   display: grid;
   gap: 12px;
   padding: 16px;
   border: 1px solid var(--surface-border-color);
   border-radius: 8px;
   background: rgba(17, 22, 30, 0.72);
+}
+
+.about-project-copy .about-contributors {
+  grid-template-columns: minmax(220px, 0.75fr) minmax(0, 1fr);
+  align-items: start;
+  margin-top: 6px;
 }
 
 .about-install dl {
@@ -476,6 +483,119 @@
   color: var(--primary-light-color);
 }
 
+.about-contributors p {
+  margin: 0;
+  color: #9da8b8;
+  font-size: 13px;
+  font-weight: 560;
+}
+
+.about-profile-group {
+  display: grid;
+  gap: 8px;
+}
+
+.about-profile-group h3 {
+  margin: 0;
+  color: #9da8b8;
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.about-owner-card,
+.about-contributor-list {
+  display: grid;
+}
+
+.about-contributor-list {
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 9px;
+}
+
+.about-owner-card,
+.about-contributor-list a {
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  min-height: 50px;
+  padding: 7px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  color: #f8fafc;
+  text-decoration: none;
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.about-owner-card {
+  grid-template-columns: 48px minmax(0, 1fr);
+  min-height: 64px;
+  padding: 9px;
+  border-color: rgba(var(--primary-light-rgb), 0.32);
+  background:
+    linear-gradient(135deg, rgba(var(--primary-rgb), 0.2), rgba(var(--primary-light-rgb), 0.08)),
+    rgba(255, 255, 255, 0.04);
+}
+
+.about-owner-card:hover,
+.about-contributor-list a:hover {
+  border-color: rgba(var(--primary-light-rgb), 0.34);
+  background: rgba(var(--primary-rgb), 0.12);
+  transform: translateY(-1px);
+}
+
+.about-owner-card img,
+.about-contributor-list img {
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.3);
+  border-radius: 999px;
+  object-fit: cover;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.about-owner-card img {
+  width: 48px;
+  height: 48px;
+}
+
+.about-owner-card span,
+.about-contributor-list span {
+  display: grid;
+  min-width: 0;
+}
+
+.about-owner-card strong,
+.about-owner-card small,
+.about-contributor-list strong,
+.about-contributor-list small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.about-owner-card strong,
+.about-contributor-list strong {
+  color: #fff;
+  font-size: 13px;
+  font-weight: 720;
+}
+
+.about-owner-card strong {
+  font-size: 15px;
+  font-weight: 820;
+}
+
+.about-owner-card small,
+.about-contributor-list small {
+  color: #9da8b8;
+  font-size: 12px;
+  font-weight: 560;
+}
+
 @media (max-width: 900px) {
   .about-layout {
     grid-template-columns: 1fr;
@@ -484,7 +604,8 @@
 
 @media (max-width: 700px) {
   .about-project-grid,
-  .about-feature-grid {
+  .about-feature-grid,
+  .about-project-copy .about-contributors {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/src/pages/css/active-transcodes.css
+++ b/apps/web/src/pages/css/active-transcodes.css
@@ -1,0 +1,406 @@
+@import "./variables.css";
+
+.transcodes-page {
+  display: grid;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  gap: 16px;
+  color: #f8fafc;
+}
+
+.transcodes-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  min-width: 0;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  padding: 18px;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(var(--primary-rgb), 0.16), transparent 34%),
+    radial-gradient(circle at 88% 0%, rgba(var(--primary-rgb), 0.16), transparent 32%),
+    rgba(11, 15, 22, 0.86);
+}
+
+.transcodes-header p,
+.transcode-job-kicker,
+.transcode-summary-grid span {
+  margin: 0;
+  color: var(--primary-light-color);
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.transcodes-header h1 {
+  margin: 4px 0 6px !important;
+  color: #fff;
+  font-size: clamp(32px, 4vw, 54px);
+  font-weight: 760 !important;
+  line-height: 1;
+}
+
+.transcodes-header span {
+  display: block;
+  color: #a8b5c7;
+  font-size: 13px;
+  font-weight: 560;
+}
+
+.transcodes-header button,
+.transcode-tabs button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.045);
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.transcodes-header button {
+  min-height: 36px;
+  padding: 0 12px;
+}
+
+.transcodes-error,
+.transcode-empty {
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  border-radius: 8px;
+  padding: 14px;
+  background: rgba(127, 29, 29, 0.12);
+  color: #fecaca;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.transcode-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  gap: 12px;
+}
+
+.transcode-summary-grid article {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 4px 12px;
+  min-width: 0;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  padding: 14px;
+  background: rgba(17, 22, 30, 0.82);
+}
+
+.transcode-summary-grid svg {
+  grid-row: span 2;
+  color: var(--primary-light-color);
+}
+
+.transcode-summary-grid strong {
+  color: #fff;
+  font-size: 26px;
+  font-weight: 760;
+  line-height: 1;
+}
+
+.transcode-tabs {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  gap: 6px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  padding: 6px;
+  overflow-x: auto;
+  background: rgba(12, 15, 22, 0.82);
+}
+
+.transcode-tabs button {
+  min-height: 34px;
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
+.transcode-tabs button.is-active {
+  border-color: rgba(var(--primary-light-rgb), 0.42);
+  background: rgba(var(--primary-rgb), 0.18);
+  color: #f4e8ff;
+}
+
+.transcode-list {
+  display: grid;
+  gap: 12px;
+}
+
+.transcode-job-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 116px minmax(0, 1fr) minmax(180px, auto);
+  grid-template-rows: minmax(88px, auto) auto;
+  align-items: center;
+  gap: 12px 18px;
+  min-height: 168px;
+  overflow: hidden;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  padding: 18px;
+  background:
+    linear-gradient(135deg, rgba(10, 14, 21, 0.96), rgba(16, 22, 32, 0.88)),
+    radial-gradient(circle at 85% 10%, rgba(var(--primary-rgb), 0.16), transparent 32%);
+  background-size: cover;
+  background-position: center;
+}
+
+.transcode-job-card::after {
+  position: absolute;
+  inset: auto 0 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--primary-color), var(--primary-light-color));
+  content: "";
+  opacity: 0.82;
+}
+
+.transcode-job-thumbnail {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 116px;
+  grid-row: 1 / -1;
+  aspect-ratio: 2 / 3;
+  place-items: center;
+  align-self: center;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(3, 7, 12, 0.66);
+  color: #f4e8ff;
+  font-size: 20px;
+  font-weight: 760;
+  text-transform: uppercase;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.28);
+}
+
+.transcode-job-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  image-rendering: auto;
+  transform: translateZ(0);
+}
+
+.transcode-job-main,
+.transcode-job-meta {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.transcode-job-main {
+  align-self: end;
+}
+
+.transcode-job-main h2 {
+  margin: 6px 0 10px !important;
+  overflow: hidden;
+  color: #fff;
+  font-size: clamp(22px, 3vw, 36px);
+  font-weight: 760 !important;
+  line-height: 1.02;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transcode-route {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 7px 10px;
+  background: rgba(3, 7, 12, 0.58);
+}
+
+.transcode-route strong {
+  overflow: hidden;
+  color: #f4e8ff;
+  font-size: 13px;
+  font-weight: 760;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transcode-route svg {
+  flex: 0 0 auto;
+  color: var(--primary-light-color);
+}
+
+.transcode-job-meta {
+  align-self: end;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 7px;
+}
+
+.transcode-job-meta span {
+  min-height: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  padding: 6px 9px;
+  background: rgba(3, 7, 12, 0.62);
+  color: #cbd5e1;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.transcode-progress {
+  position: relative;
+  grid-column: 2 / -1;
+  z-index: 1;
+  height: 24px;
+  min-width: 0;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(3, 7, 12, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.transcode-history-details {
+  position: relative;
+  z-index: 1;
+  grid-column: 2 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.transcode-history-details span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 28px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.24);
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: rgba(var(--primary-rgb), 0.12);
+  color: #f4e8ff;
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.transcode-history-details b {
+  color: #cbd5e1;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.transcode-progress span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--primary-color), var(--primary-light-color));
+}
+
+.transcode-progress em {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  height: 100%;
+  place-items: center;
+  color: #ffffff;
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 760;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+}
+
+.transcode-progress.is-indeterminate span {
+  width: 42%;
+  animation: transcode-progress-sweep 1.4s ease-in-out infinite;
+  background: linear-gradient(90deg, rgba(var(--primary-rgb), 0), rgba(var(--primary-rgb), 0.88), rgba(var(--primary-light-rgb), 0));
+}
+
+@keyframes transcode-progress-sweep {
+  0% {
+    transform: translateX(-105%);
+  }
+  100% {
+    transform: translateX(245%);
+  }
+}
+
+.transcode-reason {
+  position: relative;
+  z-index: 1;
+  grid-column: 2 / -1;
+  margin: 0;
+  color: #f4e8ff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.transcode-empty {
+  display: grid;
+  gap: 4px;
+  border-color: var(--surface-border-color);
+  background: rgba(17, 22, 30, 0.72);
+  color: #cbd5e1;
+}
+
+.transcode-empty strong {
+  color: #fff;
+  font-size: 15px;
+}
+
+.transcode-empty span {
+  color: #9aa7bb;
+  font-size: 12px;
+}
+
+@media (max-width: 720px) {
+  .transcodes-header,
+  .transcode-job-card {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+  }
+
+  .transcode-job-thumbnail {
+    grid-row: auto;
+    width: min(100%, 220px);
+    justify-self: start;
+  }
+
+  .transcodes-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .transcode-job-main h2 {
+    white-space: normal;
+  }
+
+  .transcode-job-meta {
+    justify-content: flex-start;
+  }
+
+  .transcode-reason {
+    grid-column: 1;
+  }
+
+  .transcode-progress {
+    grid-column: 1;
+  }
+}

--- a/apps/web/src/pages/css/activity/activity-table.css
+++ b/apps/web/src/pages/css/activity/activity-table.css
@@ -5,7 +5,7 @@
 }
 
 .activity-mrt-paper .MuiTable-root {
-  min-width: 980px;
+  min-width: 1120px;
 }
 
 .activity-mrt-paper .MuiTableHead-root .MuiTableRow-root {
@@ -82,8 +82,42 @@
 }
 
 .activity-user-link {
+  display: inline-grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+  max-width: 100%;
   color: #dfe7f2 !important;
   font-weight: 680;
+}
+
+.activity-user-link span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-user-avatar,
+.activity-user-avatar-fallback {
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.3);
+  border-radius: 50%;
+  background: linear-gradient(145deg, rgba(var(--primary-rgb), 0.26), rgba(12, 17, 25, 0.94));
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.24);
+}
+
+.activity-user-avatar {
+  display: block;
+  object-fit: cover;
+}
+
+.activity-user-avatar-fallback {
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 850;
 }
 
 .activity-title-link {
@@ -127,16 +161,39 @@
 }
 
 .activity-title-copy {
-  display: block;
+  display: grid;
+  gap: 4px;
   min-width: 0;
+  overflow: hidden;
+}
+
+.activity-title-copy strong,
+.activity-title-copy small {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.activity-title-copy strong {
+  color: #f8fafc;
+  font-size: 13px;
+  font-weight: 760;
+}
+
+.activity-title-copy small {
+  color: #91a0b4;
+  font-size: 11px;
+  font-weight: 680;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .activity-client-link {
   display: inline-flex;
   align-items: center;
+  max-width: 100%;
+  overflow: hidden;
   border: 1px solid rgba(var(--secondary-rgb), 0.22);
   border-radius: 6px;
   padding: 4px 8px;
@@ -144,6 +201,8 @@
   background: rgba(var(--secondary-rgb), 0.08);
   font-size: 12px;
   font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .activity-method-pill {
@@ -157,6 +216,7 @@
   font-size: 12px;
   font-weight: 650;
   text-decoration: none !important;
+  white-space: nowrap;
 }
 
 .activity-method-pill.is-transcode {
@@ -179,6 +239,22 @@
   color: #b9c5d4;
   font-size: 12px;
   line-height: 1.35;
+}
+
+.activity-device-cell,
+.activity-ip-cell,
+.activity-ip-link {
+  display: block;
+  overflow: hidden;
+  color: #c8d3e1;
+  font-size: 12px;
+  font-weight: 620;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-ip-link {
+  color: #adddeb !important;
 }
 
 .activity-duration-cell {

--- a/apps/web/src/pages/css/activity/stream-info.css
+++ b/apps/web/src/pages/css/activity/stream-info.css
@@ -1,10 +1,235 @@
 @import '../variables.css';
 
-.ellipse
-{
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
+.stream-info-modal {
+  max-width: min(680px, calc(100vw - 24px));
+}
+
+.stream-info-modal .modal-content {
+  overflow: hidden;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.24);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012)),
+    var(--secondary-background-color);
+  color: #f8fafc;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.48);
+}
+
+.stream-info-modal .modal-header,
+.stream-info-modal .modal-footer {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.stream-info-modal .modal-header {
+  padding: 14px;
+}
+
+.stream-info-modal .modal-title {
+  color: #ffffff;
+  font-size: clamp(18px, 2vw, 25px);
+  font-weight: 760;
+  line-height: 1.18;
+  letter-spacing: 0;
+}
+
+.stream-info-modal .modal-footer {
+  padding: 12px 14px;
+}
+
+.stream-info-modal .modal-footer .btn {
+  min-height: 36px;
+  border-radius: 8px;
+}
+
+.StreamInfo {
+  display: grid;
+  gap: 12px;
+  padding: 0 14px 14px;
+  color: #f8fafc;
+}
+
+.stream-info-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.stream-info-summary > div,
+.stream-info-section {
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.014)),
+    rgba(13, 18, 25, 0.86);
+}
+
+.stream-info-summary > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+  padding: 10px 12px;
+}
+
+.stream-info-summary span,
+.stream-info-columns strong,
+.stream-info-row > span {
+  color: #9caabe;
+  font-size: 11px;
+  font-weight: 720;
+}
+
+.stream-info-summary strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 760;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stream-info-section {
+  overflow: hidden;
+}
+
+.stream-info-section-header {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.stream-info-section-header h3 {
+  margin: 0;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 760;
+  letter-spacing: 0;
+}
+
+.stream-info-mode {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  padding: 0 10px;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.045);
+  color: #dbe5f2;
+  font-size: 10px;
+  font-weight: 760;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.stream-info-mode.is-direct {
+  border-color: rgba(74, 171, 188, 0.42);
+  background: rgba(74, 171, 188, 0.12);
+  color: #a7f3f8;
+}
+
+.stream-info-mode.is-direct-stream {
+  border-color: rgba(147, 197, 253, 0.38);
+  background: rgba(59, 130, 246, 0.12);
+  color: #bfdbfe;
+}
+
+.stream-info-mode.is-transcode {
+  border-color: rgba(182, 108, 200, 0.5);
+  background: rgba(182, 108, 200, 0.15);
+  color: #f0d3ff;
+}
+
+.stream-info-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.85fr) repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 12px;
+}
+
+.stream-info-columns {
+  min-height: 32px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.075);
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.stream-info-columns strong {
+  color: #c8d4e5;
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.stream-info-rows .stream-info-row:not(:last-child) {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+}
+
+.stream-info-row > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stream-info-row > strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stream-info-reasons {
+  padding-bottom: 12px;
+}
+
+.stream-info-reason-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px;
+}
+
+.stream-info-reason-list span {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  padding: 0 10px;
+  border: 1px solid rgba(182, 108, 200, 0.44);
+  border-radius: 999px;
+  background: rgba(182, 108, 200, 0.13);
+  color: #f0d3ff;
+  font-size: 11px;
+  font-weight: 720;
+}
+
+.ellipse {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 560px) {
+  .StreamInfo {
+    padding: 0 10px 10px;
+  }
+
+  .stream-info-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .stream-info-row {
+    grid-template-columns: minmax(84px, 0.72fr) repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    padding: 0 10px;
+  }
 }

--- a/apps/web/src/pages/css/automation-health.css
+++ b/apps/web/src/pages/css/automation-health.css
@@ -1,0 +1,236 @@
+@import './variables.css';
+
+.automation-health-page {
+  display: grid;
+  gap: 18px;
+  width: 100%;
+  padding: 28px clamp(18px, 3vw, 42px) 48px;
+  color: #f8fafc;
+}
+
+.automation-health-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.18);
+  border-radius: 16px;
+  padding: 24px;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(var(--primary-rgb), 0.18), transparent 36%),
+    rgba(13, 18, 27, 0.82);
+}
+
+.automation-health-header p {
+  margin: 0 0 4px;
+  color: var(--primary-light-color);
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.automation-health-header h1 {
+  margin: 0;
+  font-size: clamp(34px, 4vw, 54px);
+  font-weight: 950;
+  letter-spacing: 0;
+}
+
+.automation-health-header span {
+  display: block;
+  margin-top: 8px;
+  color: #9aa7bb;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.automation-health-header button,
+.automation-service-card button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.28);
+  border-radius: 10px;
+  padding: 10px 13px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  font-weight: 850;
+}
+
+.automation-health-error,
+.automation-empty {
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  border-radius: 14px;
+  padding: 16px;
+  background: rgba(127, 29, 29, 0.18);
+  color: #fecaca;
+  font-weight: 800;
+}
+
+.automation-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.automation-summary-grid article,
+.automation-service-card {
+  border: 1px solid rgba(var(--primary-light-rgb), 0.16);
+  border-radius: 14px;
+  background: rgba(13, 18, 27, 0.76);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.22);
+}
+
+.automation-summary-grid article {
+  display: grid;
+  gap: 5px;
+  padding: 16px;
+}
+
+.automation-summary-grid svg {
+  color: var(--primary-light-color);
+}
+
+.automation-summary-grid strong {
+  font-size: 26px;
+  font-weight: 950;
+}
+
+.automation-summary-grid span {
+  color: #9aa7bb;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.automation-service-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 14px;
+}
+
+.automation-service-card {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+}
+
+.automation-service-card.is-warning {
+  border-color: rgba(251, 191, 36, 0.3);
+}
+
+.automation-service-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.automation-service-head > span {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border-radius: 12px;
+  background: rgba(var(--primary-rgb), 0.16);
+  color: var(--primary-light-color);
+}
+
+.automation-service-head h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 950;
+}
+
+.automation-service-head p {
+  margin: 2px 0 0;
+  color: #9aa7bb;
+  font-weight: 750;
+}
+
+.automation-service-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.automation-service-metrics span,
+.automation-list p,
+.automation-issues p {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(3, 7, 12, 0.46);
+}
+
+.automation-service-metrics span {
+  display: grid;
+  gap: 2px;
+  padding: 11px;
+  color: #9aa7bb;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.automation-service-metrics strong {
+  color: #fff;
+  font-size: 20px;
+  font-weight: 950;
+}
+
+.automation-list,
+.automation-issues {
+  display: grid;
+  gap: 8px;
+}
+
+.automation-list > strong,
+.automation-issues > strong {
+  color: #fff;
+  font-size: 13px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.automation-list p,
+.automation-issues p {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0;
+  padding: 10px;
+}
+
+.automation-list span,
+.automation-issues b {
+  color: #f8fafc;
+  font-weight: 850;
+}
+
+.automation-list small,
+.automation-issues span {
+  color: #9aa7bb;
+  font-size: 12px;
+  font-weight: 750;
+  text-align: right;
+}
+
+.automation-empty {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 4px;
+  color: #cbd5e1;
+}
+
+@media (max-width: 900px) {
+  .automation-health-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .automation-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .automation-service-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/pages/css/home.css
+++ b/apps/web/src/pages/css/home.css
@@ -163,6 +163,14 @@
   font-weight: 720;
 }
 
+.home-order-panel-heading span {
+  display: block;
+  margin-top: 5px;
+  color: rgba(var(--primary-light-rgb), 0.88);
+  font-size: 12px;
+  font-weight: 650;
+}
+
 .home-order-panel-heading button {
   flex: 0 0 auto;
   padding: 0 11px;
@@ -243,6 +251,17 @@
   background: rgba(255, 255, 255, 0.035);
 }
 
+.home-order-list article.is-hidden-widget {
+  border-style: dashed;
+  background: rgba(255, 255, 255, 0.018);
+}
+
+.home-order-list article.is-dragging-widget {
+  border-color: rgba(var(--primary-light-rgb), 0.58);
+  background: rgba(var(--primary-rgb), 0.14);
+  opacity: 0.72;
+}
+
 .home-order-list article > span {
   display: grid;
   width: 24px;
@@ -256,11 +275,21 @@
 }
 
 .home-order-list strong {
+  display: grid;
   min-width: 0;
   overflow: hidden;
   color: #f8fafc;
   font-size: 13px;
   font-weight: 720;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-order-list strong small {
+  overflow: hidden;
+  color: #8fa0b8;
+  font-size: 10px;
+  font-weight: 650;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -300,12 +329,13 @@
 }
 
 .home-section-stack {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
   gap: 18px;
 }
 
 .home-section-stack > section {
+  grid-column: span 12;
   margin-top: 0 !important;
   margin-bottom: 0 !important;
 }
@@ -318,6 +348,7 @@
 .home-density-compact .home-metric-card,
 .home-density-compact .home-catalog-card,
 .home-density-compact .home-ops-card,
+.home-density-compact .home-integration-widget,
 .home-density-compact .home-week-pulse,
 .home-density-compact .home-attention-section,
 .home-density-compact .home-watch-party,
@@ -337,6 +368,10 @@
 
 .is-rotating-home .home-section-stack {
   min-height: 48vh;
+}
+
+.is-kiosk-home.is-rotating-home .home-section-stack {
+  min-height: 0;
 }
 
 .is-kiosk-home {
@@ -392,7 +427,21 @@
 }
 
 .home-widget-size-small {
+  grid-column: span 4;
   transform-origin: top center;
+}
+
+.home-widget-size-medium {
+  grid-column: span 6;
+}
+
+.home-widget-size-large {
+  grid-column: span 12;
+}
+
+.is-home-widget-editing {
+  outline: 1px dashed rgba(var(--primary-light-rgb), 0.38);
+  outline-offset: 4px;
 }
 
 .home-widget-size-small.home-week-pulse,
@@ -458,6 +507,11 @@
   color: #9cabbe;
   font-size: 13px;
   font-weight: 800;
+}
+
+.is-kiosk-home .home-active-sessions:has(.sessions-widget-empty),
+.is-kiosk-home .home-active-sessions:has(.sessions-widget-loading) {
+  min-height: 0;
 }
 
 .sessions-loading-strip {
@@ -1084,6 +1138,125 @@
   font-weight: 800;
 }
 
+.home-integration-widget {
+  display: flex;
+  min-height: 210px;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+
+.home-integration-widget-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.home-integration-widget-head p {
+  margin: 0 0 4px;
+  color: #9dddf0;
+  font-size: 10px;
+  font-weight: 950;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.home-integration-widget-head h2 {
+  margin: 0;
+  overflow: hidden;
+  color: #fff;
+  font-size: 20px;
+  font-weight: 950;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-integration-widget-head a {
+  display: inline-flex;
+  min-height: 31px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 11px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.28);
+  border-radius: 8px;
+  background: rgba(var(--primary-rgb), 0.12);
+  color: #f7dcff;
+  font-size: 11px;
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.home-integration-status {
+  display: block;
+  color: #fff;
+  font-size: 28px;
+  font-weight: 950;
+  line-height: 1;
+}
+
+.home-integration-detail {
+  display: block;
+  min-height: 34px;
+  color: #9cabbe;
+  font-size: 12px;
+  font-weight: 780;
+  line-height: 1.35;
+}
+
+.home-integration-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: auto;
+}
+
+.home-integration-stat-grid span {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.home-integration-stat-grid b,
+.home-integration-stat-grid em {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-integration-stat-grid b {
+  color: #fff;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 950;
+}
+
+.home-integration-stat-grid em {
+  margin-top: 4px;
+  color: #9cabbe;
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-integration-empty {
+  display: flex;
+  min-height: 102px;
+  align-items: center;
+  padding: 14px;
+  border: 1px dashed rgba(var(--primary-light-rgb), 0.22);
+  border-radius: 8px;
+  color: #b7c4d6;
+  font-size: 12px;
+  font-weight: 780;
+  line-height: 1.45;
+}
+
 .home-request-preview {
   margin-top: 18px;
   padding: 16px;
@@ -1218,8 +1391,15 @@
 .home-hall-grid {
   display: grid;
   grid-template-columns: minmax(390px, 0.9fr) minmax(420px, 1.7fr);
-  gap: 22px;
+  gap: 18px;
   align-items: end;
+  padding: 16px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.16);
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(255, 201, 84, 0.1), transparent 30%),
+    linear-gradient(135deg, rgba(var(--primary-rgb), 0.1), rgba(8, 11, 18, 0.78)),
+    rgba(8, 10, 16, 0.72);
 }
 
 .home-podium {
@@ -1227,7 +1407,7 @@
   grid-template-columns: repeat(3, minmax(104px, 1fr));
   align-items: end;
   gap: 12px;
-  min-height: 166px;
+  min-height: 206px;
 }
 
 .home-podium-card {
@@ -1236,36 +1416,65 @@
   flex-direction: column;
   align-items: center;
   justify-content: end;
-  gap: 8px;
-  min-height: 134px;
-  padding: 28px 14px 17px;
+  gap: 7px;
+  min-height: 142px;
+  padding: 32px 14px 17px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.22);
-  border-radius: 10px;
+  border-radius: 12px;
   background:
+    radial-gradient(circle at 50% 10%, rgba(var(--primary-light-rgb), 0.12), transparent 38%),
     linear-gradient(160deg, rgba(35, 29, 48, 0.9), rgba(14, 13, 20, 0.88)),
     rgba(10, 10, 16, 0.9);
   box-shadow: 0 16px 34px rgba(0, 0, 0, 0.24), inset 0 1px rgba(255, 255, 255, 0.035);
   text-align: center;
 }
 
+.home-podium-card::after {
+  content: "";
+  position: absolute;
+  right: 14px;
+  bottom: 8px;
+  left: 14px;
+  height: 3px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
 .home-podium-card.rank-1 {
-  min-height: 166px;
+  min-height: 204px;
   border-color: rgba(255, 201, 84, 0.72);
   background:
-    radial-gradient(circle at 50% 14%, rgba(255, 201, 84, 0.14), transparent 32%),
+    radial-gradient(circle at 50% 10%, rgba(255, 201, 84, 0.2), transparent 36%),
     linear-gradient(160deg, rgba(35, 31, 46, 0.94), rgba(14, 13, 20, 0.9));
   box-shadow: 0 0 0 1px rgba(255, 201, 84, 0.18), 0 20px 42px rgba(0, 0, 0, 0.3);
 }
 
+.home-podium-card.rank-2 {
+  min-height: 174px;
+  border-color: rgba(226, 232, 240, 0.48);
+  background:
+    radial-gradient(circle at 50% 10%, rgba(226, 232, 240, 0.14), transparent 38%),
+    linear-gradient(160deg, rgba(34, 35, 46, 0.94), rgba(14, 13, 20, 0.9));
+}
+
+.home-podium-card.rank-3 {
+  min-height: 160px;
+  border-color: rgba(205, 127, 50, 0.52);
+  background:
+    radial-gradient(circle at 50% 10%, rgba(205, 127, 50, 0.16), transparent 38%),
+    linear-gradient(160deg, rgba(36, 28, 26, 0.94), rgba(14, 13, 20, 0.9));
+}
+
 .home-rank-medal {
   position: absolute;
-  top: -15px;
+  top: -24px;
   display: grid;
-  min-width: 34px;
-  height: 30px;
-  padding: 0 10px;
+  min-width: 58px;
+  min-height: 48px;
+  padding: 7px 10px 6px;
   place-items: center;
-  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 16px;
   color: #fff;
   background: linear-gradient(135deg, var(--primary-color), #dc7ee9);
   font-size: 12px;
@@ -1273,9 +1482,34 @@
   box-shadow: 0 10px 22px rgba(0, 0, 0, 0.28);
 }
 
+.home-rank-medal span {
+  color: inherit;
+  font-size: 9px;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.home-rank-medal svg {
+  color: inherit;
+  width: 18px;
+  height: 18px;
+}
+
 .rank-1 .home-rank-medal {
   background: linear-gradient(135deg, #ffd66f, #f4b846);
   color: #160b18;
+}
+
+.rank-2 .home-rank-medal {
+  background: linear-gradient(135deg, #f8fafc, #94a3b8);
+  color: #111827;
+}
+
+.rank-3 .home-rank-medal {
+  background: linear-gradient(135deg, #e6a765, #9a5b2f);
+  color: #180d08;
 }
 
 .home-avatar {
@@ -1308,10 +1542,32 @@
   font-weight: 800;
 }
 
+.home-podium-share {
+  width: 100%;
+  height: 5px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.home-podium-share::before {
+  content: "";
+  display: block;
+  width: var(--hall-share, 28%);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--primary-color), var(--primary-light-color));
+  box-shadow: 0 0 14px rgba(var(--primary-rgb), 0.28);
+}
+
+.rank-1 .home-podium-share::before {
+  background: linear-gradient(90deg, #f4b846, #ffe59b);
+}
+
 .home-runner-list {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
   align-self: center;
 }
 
@@ -1321,13 +1577,27 @@
   grid-template-columns: 44px 38px minmax(120px, 1fr) auto;
   align-items: center;
   min-height: 54px;
-  padding: 8px 12px;
+  padding: 9px 12px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.2);
-  border-radius: 10px;
+  border-radius: 12px;
   background:
-    linear-gradient(90deg, rgba(26, 22, 34, 0.86), rgba(10, 11, 16, 0.72)),
+    linear-gradient(90deg, rgba(26, 22, 34, 0.9), rgba(10, 11, 16, 0.74)),
     rgba(10, 10, 16, 0.8);
   backdrop-filter: blur(14px);
+}
+
+.home-runner-row > span:first-child {
+  display: inline-flex;
+  width: 34px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.18);
+  border-radius: 999px;
+  background: rgba(var(--primary-rgb), 0.12);
+  color: var(--primary-light-color);
+  font-size: 12px;
+  font-weight: 950;
 }
 
 .home-runner-row > span {
@@ -1346,6 +1616,11 @@
 }
 
 @media (max-width: 1180px) {
+  .home-widget-size-small,
+  .home-widget-size-medium {
+    grid-column: span 6;
+  }
+
   .home-hero-grid,
   .home-secondary-grid,
   .home-catalog-grid,
@@ -1356,6 +1631,7 @@
   .home-milestone-grid,
   .home-quick-action-grid,
   .home-order-options,
+  .home-integration-stat-grid,
   .home-ops-grid {
     grid-template-columns: repeat(2, minmax(220px, 1fr));
   }
@@ -1370,6 +1646,12 @@
 }
 
 @media (max-width: 900px) {
+  .home-widget-size-small,
+  .home-widget-size-medium,
+  .home-widget-size-large {
+    grid-column: 1 / -1;
+  }
+
   .Home {
     padding: 14px 12px 32px;
   }
@@ -1480,6 +1762,7 @@
   .home-milestone-grid,
   .home-quick-action-grid,
   .home-order-options,
+  .home-integration-stat-grid,
   .home-ops-grid,
   .home-hall-grid {
     grid-template-columns: 1fr;
@@ -1502,7 +1785,12 @@
 
   .home-podium-card,
   .home-podium-card.rank-1 {
-    min-height: 132px;
+    min-height: 150px;
+  }
+
+  .home-podium-card.rank-2,
+  .home-podium-card.rank-3 {
+    min-height: 142px;
   }
 
   .home-request-preview-heading,

--- a/apps/web/src/pages/css/integrations.css
+++ b/apps/web/src/pages/css/integrations.css
@@ -250,18 +250,25 @@
   font-weight: 750;
 }
 
+.integration-link-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .integration-link-panel a,
 .wizarr-refresh-button,
 .wizarr-create-card > button {
   display: inline-flex;
-  min-height: 40px;
+  min-height: 38px;
   align-items: center;
   justify-content: center;
   gap: 8px;
   padding: 0 14px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.36);
-  border-radius: 10px;
-  background: rgba(var(--primary-rgb), 0.5);
+  border-radius: 8px;
+  background: rgba(var(--primary-rgb), 0.34);
   color: #fff;
   font-weight: 950;
   text-decoration: none;
@@ -269,7 +276,7 @@
 
 .wizarr-dashboard {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(160px, 1fr));
   gap: 12px;
 }
 
@@ -277,25 +284,28 @@
 .wizarr-create-card,
 .wizarr-invite-card {
   border: 1px solid rgba(var(--primary-light-rgb), 0.18);
-  border-radius: 14px;
+  border-radius: 8px;
   background: rgba(11, 15, 24, 0.84);
-  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.22);
 }
 
 .wizarr-dashboard article {
   display: grid;
-  gap: 8px;
-  min-height: 92px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px 12px;
+  min-height: 82px;
   align-content: center;
-  padding: 16px;
+  align-items: center;
+  padding: 14px;
   background:
     linear-gradient(135deg, rgba(var(--primary-rgb), 0.18), rgba(255, 255, 255, 0.03)),
     rgba(11, 15, 24, 0.88);
 }
 
 .wizarr-dashboard strong {
+  grid-column: 1 / -1;
   color: #fff;
-  font-size: 34px;
+  font-size: 30px;
   font-weight: 950;
   line-height: 0.9;
 }
@@ -308,19 +318,25 @@
   text-transform: uppercase;
 }
 
+.wizarr-dashboard small {
+  color: #8fa0b8;
+  font-size: 12px;
+  font-weight: 800;
+}
+
 .wizarr-layout {
   display: grid;
-  grid-template-columns: minmax(340px, 430px) minmax(0, 1fr);
+  grid-template-columns: minmax(520px, 1.15fr) minmax(360px, 0.85fr);
   gap: 14px;
   align-items: start;
 }
 
 .wizarr-create-card {
   display: grid;
-  gap: 16px;
+  gap: 14px;
   position: sticky;
   top: 14px;
-  padding: 16px;
+  padding: 14px;
   overflow: hidden;
   background:
     linear-gradient(180deg, rgba(var(--primary-rgb), 0.12), rgba(255, 255, 255, 0.02)),
@@ -343,8 +359,8 @@
   gap: 10px;
   padding: 12px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.13);
-  border-radius: 12px;
-  background: rgba(5, 8, 13, 0.34);
+  border-radius: 8px;
+  background: rgba(5, 8, 13, 0.42);
 }
 
 .wizarr-form-heading {
@@ -369,7 +385,7 @@
   min-height: 28px;
   padding: 0 10px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.26);
-  border-radius: 999px;
+  border-radius: 8px;
   background: rgba(var(--primary-rgb), 0.22);
   color: #fff;
   font-size: 11px;
@@ -387,7 +403,7 @@
 .wizarr-create-card input:not([type]) {
   min-height: 42px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.24);
-  border-radius: 10px;
+  border-radius: 8px;
   background: #0b101a;
   color: #f8fafc;
   padding: 0 12px;
@@ -416,20 +432,20 @@
 
 .wizarr-choice-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 8px;
-  max-height: 220px;
+  max-height: 190px;
   overflow: auto;
   padding-right: 2px;
 }
 
 .wizarr-choice-grid button {
   display: grid;
-  gap: 2px;
-  min-height: 58px;
-  padding: 10px;
+  gap: 4px;
+  min-height: 62px;
+  padding: 11px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.18);
-  border-radius: 10px;
+  border-radius: 8px;
   background: rgba(16, 22, 34, 0.88);
   color: #dfe7f3;
   text-align: left;
@@ -486,7 +502,7 @@
   gap: 8px;
   padding: 0 10px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.18);
-  border-radius: 999px;
+  border-radius: 8px;
   background: rgba(16, 22, 34, 0.88);
   color: #dbe6f5;
   letter-spacing: 0;
@@ -498,7 +514,7 @@
   gap: 10px;
   padding: 12px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.14);
-  border-radius: 12px;
+  border-radius: 8px;
   background:
     linear-gradient(135deg, rgba(var(--secondary-rgb), 0.08), transparent 50%),
     rgba(5, 8, 13, 0.34);
@@ -543,7 +559,7 @@
   gap: 12px;
   padding: 14px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.18);
-  border-radius: 14px;
+  border-radius: 8px;
   background: rgba(8, 11, 17, 0.68);
 }
 
@@ -574,7 +590,7 @@
   gap: 8px;
   padding: 0 12px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.2);
-  border-radius: 10px;
+  border-radius: 8px;
   background: #080c14;
   color: #96a8bf;
 }
@@ -599,7 +615,7 @@
   min-height: 34px;
   padding: 0 12px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.18);
-  border-radius: 999px;
+  border-radius: 8px;
   background: rgba(16, 22, 34, 0.72);
   color: #c7d4e5;
   font-size: 12px;
@@ -614,17 +630,19 @@
 
 .wizarr-invite-list {
   display: grid;
-  gap: 10px;
+  grid-template-columns: 1fr;
+  gap: 12px;
 }
 
 .wizarr-invite-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(180px, auto) auto;
-  align-items: center;
-  gap: 16px;
-  padding: 16px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 14px;
+  min-height: 190px;
+  padding: 14px;
   background:
-    linear-gradient(90deg, rgba(20, 26, 39, 0.96), rgba(10, 14, 22, 0.86)),
+    linear-gradient(145deg, rgba(20, 26, 39, 0.96), rgba(10, 14, 22, 0.86)),
     rgba(11, 15, 24, 0.9);
 }
 
@@ -633,7 +651,7 @@
   min-height: 22px;
   align-items: center;
   padding: 0 8px;
-  border-radius: 999px;
+  border-radius: 8px;
   background: rgba(34, 197, 94, 0.14);
   color: #86efac;
   font-size: 11px;
@@ -647,9 +665,9 @@
 }
 
 .wizarr-invite-card h2 {
-  margin: 7px 0 2px !important;
+  margin: 8px 0 4px !important;
   color: #fff;
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 950;
 }
 
@@ -662,7 +680,7 @@
 }
 
 .wizarr-invite-card p {
-  max-width: 720px;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -670,8 +688,10 @@
 
 .wizarr-invite-meta {
   display: grid;
-  gap: 4px;
-  justify-items: end;
+  grid-column: 1 / -1;
+  gap: 6px;
+  justify-items: start;
+  align-self: end;
 }
 
 .wizarr-invite-actions {
@@ -687,7 +707,7 @@
   align-items: center;
   justify-content: center;
   border: 1px solid rgba(var(--primary-light-rgb), 0.26);
-  border-radius: 10px;
+  border-radius: 8px;
   background: rgba(var(--primary-rgb), 0.22);
   color: #fff;
 }
@@ -698,9 +718,13 @@
   color: #fecaca;
 }
 
+.wizarr-invite-actions a[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.42;
+}
+
 @media (max-width: 1100px) {
-  .wizarr-layout,
-  .wizarr-invite-card {
+  .wizarr-layout {
     grid-template-columns: 1fr;
   }
 
@@ -713,6 +737,10 @@
   .integration-link-panel,
   .integration-page-header {
     grid-template-columns: 1fr;
+  }
+
+  .integration-link-actions {
+    justify-content: flex-start;
   }
 
   .wizarr-dashboard,
@@ -1771,20 +1799,27 @@
 
 .requests-control-bar {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(170px, 220px) minmax(92px, auto);
+  grid-template-columns: minmax(0, 1fr) minmax(92px, auto);
   align-items: end;
   gap: 10px;
   min-width: 0;
   padding: 10px;
 }
 
-.requests-control-bar label {
+.requests-control-bar.has-user-filter {
+  grid-template-columns: minmax(160px, 220px) minmax(160px, 220px) minmax(92px, auto);
+}
+
+.requests-control-bar label,
+.requests-filter-dropdown {
   display: grid;
   gap: 5px;
   min-width: 0;
+  position: relative;
 }
 
-.requests-control-bar label > span {
+.requests-control-bar label > span,
+.requests-filter-dropdown > span {
   color: var(--primary-light-color);
   font-size: 11px;
   font-weight: 950;
@@ -1793,7 +1828,8 @@
 }
 
 .requests-control-bar input,
-.requests-control-bar select {
+.requests-control-bar select,
+.requests-filter-dropdown > button {
   box-sizing: border-box;
   width: 100%;
   height: 38px;
@@ -1806,21 +1842,152 @@
   outline: none;
 }
 
+.requests-filter-dropdown > button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: flex-start;
+  padding: 0 36px 0 12px;
+  border-color: rgba(var(--primary-light-rgb), 0.34);
+  background:
+    linear-gradient(45deg, transparent 50%, #d9c7ff 50%) right 17px center / 7px 7px no-repeat,
+    linear-gradient(135deg, #d9c7ff 50%, transparent 50%) right 12px center / 7px 7px no-repeat,
+    linear-gradient(180deg, rgba(var(--primary-rgb), 0.18), rgba(4, 8, 17, 0.92)),
+    #0b0f1a;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 10px 24px rgba(0, 0, 0, 0.18);
+  text-align: left;
+}
+
+.requests-filter-dropdown > button strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 900;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.requests-filter-dropdown > button:focus-visible,
+.requests-filter-dropdown.is-open > button {
+  border-color: rgba(var(--primary-light-rgb), 0.58);
+  box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.16);
+}
+
+.requests-filter-dropdown-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 6px);
+  left: 0;
+  display: grid;
+  width: min(280px, 100%);
+  max-height: 260px;
+  overflow: auto;
+  padding: 6px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.32);
+  border-radius: 12px;
+  background:
+    linear-gradient(180deg, rgba(18, 24, 38, 0.98), rgba(7, 10, 16, 0.98)),
+    #0b0f1a;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.42);
+}
+
+.requests-filter-dropdown-menu button {
+  display: flex;
+  min-width: 0;
+  min-height: 34px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #dce6f7;
+  font-size: 13px;
+  font-weight: 850;
+  text-align: left;
+}
+
+.requests-filter-dropdown-menu button > span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.requests-filter-option-avatar {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(var(--primary-rgb), 0.18);
+  color: #fff;
+  font-size: 9px;
+  font-weight: 950;
+}
+
+.requests-filter-option-avatar img,
+.requests-filter-option-avatar img + span {
+  grid-area: 1 / 1;
+}
+
+.requests-filter-option-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  position: relative;
+  z-index: 1;
+}
+
+.requests-filter-dropdown-menu button:hover,
+.requests-filter-dropdown-menu button:focus-visible,
+.requests-filter-dropdown-menu button.is-selected {
+  background:
+    linear-gradient(180deg, rgba(var(--primary-light-rgb), 0.24), rgba(var(--primary-rgb), 0.28)),
+    #241934;
+  color: #ffffff;
+  outline: none;
+}
+
 .requests-control-bar input {
   padding: 0 12px;
 }
 
 .requests-control-bar select {
-  padding: 0 10px;
-  background-color: #111827;
+  appearance: none;
+  padding: 0 36px 0 12px;
+  border-color: rgba(var(--primary-light-rgb), 0.34);
+  background:
+    linear-gradient(45deg, transparent 50%, #d9c7ff 50%) right 17px center / 7px 7px no-repeat,
+    linear-gradient(135deg, #d9c7ff 50%, transparent 50%) right 12px center / 7px 7px no-repeat,
+    linear-gradient(180deg, rgba(var(--primary-rgb), 0.18), rgba(4, 8, 17, 0.92)),
+    #0b0f1a;
   color: #ffffff;
   color-scheme: dark;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 10px 24px rgba(0, 0, 0, 0.18);
 }
 
 .requests-control-bar select option {
-  background-color: #111827;
+  background-color: #0b0f1a;
   color: #ffffff;
   font-weight: 800;
+}
+
+.requests-control-bar select option:checked,
+.requests-control-bar select option:hover,
+.requests-control-bar select option:focus {
+  background:
+    linear-gradient(180deg, rgba(var(--primary-light-rgb), 0.34), rgba(var(--primary-rgb), 0.38)),
+    #241934;
+  color: #ffffff;
 }
 
 .requests-control-bar input:focus,
@@ -1840,6 +2007,35 @@
   background: rgba(var(--primary-rgb), 0.12);
   color: #f8d6ff;
   white-space: nowrap;
+}
+
+.requests-view-toggle {
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
+  align-self: center;
+  justify-self: end;
+  width: 82px;
+  height: 36px;
+  overflow: hidden;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.22);
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.42);
+}
+
+.requests-view-toggle button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: #aebbd0;
+}
+
+.requests-view-toggle button.is-active {
+  background:
+    linear-gradient(180deg, rgba(var(--primary-light-rgb), 0.26), rgba(var(--primary-rgb), 0.28)),
+    rgba(var(--primary-rgb), 0.18);
+  color: #fff;
 }
 
 .requests-board {
@@ -2177,6 +2373,90 @@
 .requests-card-actions button:disabled,
 .requests-detail-actions button:disabled {
   opacity: 0.5;
+}
+
+.requests-board.is-cards {
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 360px), 1fr));
+  gap: 14px;
+}
+
+.requests-board.is-cards article {
+  grid-template-columns: 104px minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(58px, 1fr) auto auto;
+  gap: 10px 13px;
+  height: 100%;
+  min-height: 336px;
+  padding: 14px;
+  background:
+    linear-gradient(180deg, rgba(7, 10, 16, 0.7) 0%, rgba(7, 10, 16, 0.94) 50%, rgba(7, 10, 16, 0.98) 100%),
+    var(--request-backdrop),
+    rgba(16, 21, 32, 0.92);
+  background-position: center;
+  background-size: cover;
+}
+
+.requests-board.is-cards .requests-card-poster {
+  grid-row: 1 / span 2;
+  width: 104px;
+  height: 156px;
+}
+
+.requests-board.is-cards .requests-card-title,
+.requests-board.is-cards .requests-card-meta {
+  grid-column: 2;
+}
+
+.requests-board.is-cards .requests-card-title {
+  align-self: stretch;
+  gap: 8px;
+  min-height: 82px;
+}
+
+.requests-board.is-cards .requests-card-title strong {
+  display: -webkit-box;
+  overflow: hidden;
+  font-size: 17px;
+  line-height: 1.18;
+  white-space: normal;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.requests-board.is-cards .requests-requester-byline {
+  max-width: 100%;
+}
+
+.requests-board.is-cards .requests-card-meta {
+  align-content: start;
+  min-height: 50px;
+}
+
+.requests-board.is-cards .requests-card-tags,
+.requests-board.is-cards .requests-card-overview,
+.requests-board.is-cards .requests-card-footer,
+.requests-board.is-cards .requests-card-actions {
+  grid-column: 1 / -1;
+}
+
+.requests-board.is-cards .requests-card-overview {
+  min-height: 54px;
+  -webkit-line-clamp: 3;
+}
+
+.requests-board.is-cards .requests-card-footer {
+  min-height: 26px;
+}
+
+.requests-board.is-cards .requests-card-actions {
+  grid-row: auto;
+  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+  align-self: end;
+  margin-top: 2px;
+}
+
+.requests-board.is-cards .requests-card-actions button {
+  width: 100%;
+  min-width: 0;
 }
 
 .requests-availability b {
@@ -4716,9 +4996,7 @@
 .requests-page {
   grid-template-columns: minmax(0, 1fr);
   grid-template-areas:
-    "hero"
     "message"
-    "summary"
     "discover"
     "board";
   align-items: start;
@@ -4804,10 +5082,11 @@
   gap: 16px;
   padding-bottom: 12px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .requests-page .requests-discovery-head h2 {
-  font-size: clamp(30px, 3vw, 42px);
+  font-size: clamp(26px, 2.4vw, 34px);
   line-height: 1;
 }
 
@@ -4837,6 +5116,10 @@
 
 .requests-page .requests-discovery .requests-control-bar {
   grid-template-columns: minmax(190px, 240px) auto;
+}
+
+.requests-page .requests-discovery .requests-control-bar.has-user-filter {
+  grid-template-columns: minmax(170px, 220px) minmax(170px, 220px) auto;
 }
 
 .requests-page .requests-discovery-prompt {
@@ -4869,17 +5152,61 @@
   background-size: cover;
 }
 
+.requests-page .requests-discovery .requests-control-bar {
+  grid-template-columns: minmax(190px, 240px) auto;
+}
+
+.requests-page .requests-discovery .requests-control-bar.has-user-filter {
+  grid-template-columns: minmax(170px, 220px) minmax(170px, 220px) auto;
+}
+
+.requests-page .requests-board.is-cards {
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 360px), 1fr));
+}
+
+.requests-page .requests-board.is-cards article {
+  grid-template-columns: 104px minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(58px, 1fr) auto auto;
+  min-height: 336px;
+  background:
+    linear-gradient(180deg, rgba(7, 10, 16, 0.68) 0%, rgba(7, 10, 16, 0.94) 50%, rgba(7, 10, 16, 0.98) 100%),
+    var(--request-backdrop),
+    rgba(16, 21, 32, 0.92);
+  background-position: center;
+  background-size: cover;
+}
+
+.requests-page .requests-board.is-list {
+  grid-template-columns: 1fr;
+}
+
 @media (max-width: 1180px) {
   .requests-page {
     grid-template-areas:
-      "hero"
       "message"
-      "summary"
       "discover"
       "board";
   }
 
   .requests-page .requests-summary-grid {
     grid-template-columns: repeat(auto-fit, minmax(min(190px, 100%), 1fr)) !important;
+  }
+}
+
+@media (max-width: 900px) {
+  .requests-page .requests-discovery .requests-control-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .requests-view-toggle {
+    width: 100%;
+  }
+
+  .requests-page .requests-board.is-cards article {
+    grid-template-columns: 96px minmax(0, 1fr);
+  }
+
+  .requests-board.is-cards .requests-card-poster {
+    width: 96px;
   }
 }

--- a/apps/web/src/pages/css/library/libraries.css
+++ b/apps/web/src/pages/css/library/libraries.css
@@ -1,5 +1,9 @@
 .libraries {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
   min-height: 100vh;
+  overflow-x: hidden;
   padding: 28px clamp(18px, 3vw, 42px) 48px;
   background:
     radial-gradient(circle at 18% 0%, rgba(var(--primary-rgb), 0.18), transparent 32%),
@@ -92,7 +96,10 @@
 
 .libraries-container {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
   gap: 18px;
   color: white;
 }
@@ -305,13 +312,13 @@
 
 @media (max-width: 1280px) {
   .libraries-container {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 360px), 1fr));
   }
 }
 
 @media (max-width: 980px) {
   .libraries-container {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
   }
 }
 

--- a/apps/web/src/pages/css/library/library-card.css
+++ b/apps/web/src/pages/css/library/library-card.css
@@ -209,8 +209,9 @@
   overflow: hidden;
   margin-top: 4px;
   color: #f8fafc;
-  font-size: 16px;
+  font-size: clamp(13px, 0.9vw, 16px);
   font-weight: 950;
+  line-height: 1.15;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/web/src/pages/css/navbar.css
+++ b/apps/web/src/pages/css/navbar.css
@@ -1,4 +1,8 @@
 @import './variables.css';
+:root {
+  --jg-sidebar-width: 250px;
+}
+
 .navbar {
   position: relative;
   background: rgba(10, 13, 18, 0.98);
@@ -16,8 +20,14 @@
 
 @media (min-width: 901px) and (hover: hover) {
   .navbar {
-    min-height: 100vh;
-    width: 250px;
+    position: fixed !important;
+    top: 0;
+    left: 0;
+    z-index: 1030;
+    min-height: 125vh;
+    height: 125vh;
+    width: var(--jg-sidebar-width, 250px);
+    overflow: visible;
     border-bottom: 1px solid rgba(255, 255, 255, 0.09) !important;
 
   }
@@ -25,9 +35,15 @@
   .navbar > .sticky-top {
     display: flex;
     width: 100%;
-    min-height: 100vh;
+    min-height: 125vh;
+    height: 125vh;
     flex-direction: column;
     padding-bottom: 18px;
+    overflow: hidden;
+  }
+
+  .App > .d-flex {
+    padding-left: var(--jg-sidebar-width, 250px);
   }
 }
 
@@ -391,6 +407,14 @@
   }
 }
 
+.navbar-brand-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
+  padding: 0 10px;
+}
+
 .navbar .navbar-brand{
   margin-top: 20px;
   display: flex;
@@ -399,7 +423,41 @@
   gap: 8px;
   font-size: 0;
   font-weight: 800;
-  padding: 0 18px;
+  min-width: 0;
+  padding: 0 8px;
+}
+
+.navbar-brand-icon {
+  height: 52px;
+  object-fit: contain;
+}
+
+.navbar-collapse-toggle {
+  position: absolute;
+  top: 50%;
+  right: -22px;
+  z-index: 2;
+  display: inline-flex !important;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  align-items: center;
+  justify-content: center;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.2);
+  border-radius: 12px !important;
+  background: rgba(255, 255, 255, 0.045);
+  color: #dfe7f2;
+  font: inherit;
+  transition: border-color 160ms ease, background 160ms ease, color 160ms ease;
+  transform: translateY(-50%);
+}
+
+.navbar-collapse-toggle:hover {
+  border-color: rgba(var(--primary-light-rgb), 0.44);
+  background: rgba(var(--primary-rgb), 0.18);
+  color: #fff;
 }
 
 .navbar-wordmark {
@@ -417,7 +475,15 @@
 
 @media (min-width: 901px) and (hover: hover) {
   .navbar .navbar-nav {
+    display: flex !important;
+    min-height: 0;
     flex: 1;
+    flex-direction: column !important;
+  }
+
+  .navbar-inline-footer {
+    margin-top: auto !important;
+    padding-bottom: 12px;
   }
 }
 
@@ -437,10 +503,20 @@
   padding-top: 10px;
 }
 
+.navbar-footer-account-row {
+  position: relative;
+  display: grid;
+  width: calc(100% - 24px);
+  grid-template-columns: minmax(0, 1fr);
+  align-items: center;
+  margin: 0 auto;
+}
+
 .account-navitem {
   display: flex;
-  width: 90%;
-  margin: 0 auto;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
   padding: 7px 12px !important;
   border-radius: 999px !important;
   color: rgba(226, 232, 240, 0.9) !important;
@@ -450,32 +526,6 @@
   border: 1px solid transparent;
   font: inherit;
   text-align: left;
-}
-
-.footer-logout {
-  display: flex !important;
-  width: 90%;
-  justify-content: center;
-  margin: 0 auto !important;
-  padding: 7px 12px !important;
-  border: 1px solid transparent;
-  border-radius: 12px !important;
-  background: transparent;
-  color: rgba(226, 232, 240, 0.86) !important;
-  font: inherit;
-  text-align: center;
-}
-
-.footer-logout:hover {
-  color: #ffffff !important;
-  border-color: rgba(var(--primary-rgb), 0.28);
-  background: rgba(var(--primary-rgb), 0.14) !important;
-}
-
-.footer-logout .nav-text {
-  display: flex;
-  flex: 0 0 auto;
-  margin-left: 10px;
 }
 
 .account-navitem:hover {
@@ -532,29 +582,43 @@
 
 .account-nav-copy small {
   display: block;
+  max-width: 132px;
+  overflow: hidden;
   margin-top: 4px;
   color: #94a3b8;
   font-size: 13px;
   font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.navbar-inline-footer .version {
+.navbar-version-row {
+  display: block;
+  width: 90%;
+  margin: 0 auto;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.18);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.035);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.navbar-version-row .version {
   position: static !important;
-  width: 90% !important;
+  width: 100% !important;
   max-width: none !important;
-  margin: 0 auto !important;
+  margin: 0 !important;
   background: transparent !important;
 }
 
-.navbar-inline-footer .version .card-body {
-  padding: 4px 12px 6px;
+.navbar-version-row .version .card-body {
+  padding: 7px 10px 8px;
   color: #cbd5e1;
   font-size: 12px;
   text-align: center;
 }
 
-.navbar-inline-footer .version .row,
-.navbar-inline-footer .version .col {
+.navbar-version-row .version .row,
+.navbar-version-row .version .col {
   margin: 0;
   padding: 0;
   text-align: center;
@@ -571,7 +635,7 @@
 
 
 .navitem {
-
+  position: relative;
   color: rgba(226, 232, 240, 0.86) !important;
   font-size: 15px !important;
   font-weight: 750;
@@ -584,6 +648,10 @@
   margin-bottom: 0;
   width: 90%;
   align-items: center;
+}
+
+.nav-icon-badge {
+  display: none;
 }
 
 @media (min-width: 901px) and (hover: hover) {
@@ -653,6 +721,122 @@
   box-shadow: 0 0 18px rgba(var(--primary-rgb), 0.28);
 }
 
+@media (min-width: 901px) and (hover: hover) {
+  .desktop-navigation.is-collapsed .sticky-top {
+    align-items: center;
+    padding-top: 10px !important;
+  }
+
+  .desktop-navigation.is-collapsed .navbar-brand-row {
+    justify-items: center;
+    padding: 0;
+  }
+
+  .desktop-navigation.is-collapsed .navbar .navbar-brand,
+  .desktop-navigation.is-collapsed .navbar-brand {
+    margin-top: 4px;
+    padding: 0;
+  }
+
+  .desktop-navigation.is-collapsed .navbar-brand-icon {
+    height: 42px;
+    padding: 0 !important;
+  }
+
+  .desktop-navigation.is-collapsed .navbar-wordmark {
+    display: none;
+  }
+
+  .desktop-navigation.is-collapsed .navbar-collapse-toggle {
+    right: -20px;
+    width: 42px;
+    height: 42px;
+    flex-basis: 42px;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  .desktop-navigation.is-collapsed .navbar-nav {
+    align-items: center;
+    gap: 7px;
+    margin-top: 18px;
+  }
+
+  .desktop-navigation.is-collapsed .navitem {
+    width: 46px;
+    min-height: 42px;
+    justify-content: center;
+    margin-right: 0;
+    margin-left: 0;
+    border-radius: 12px !important;
+    padding: 0 !important;
+  }
+
+  .desktop-navigation.is-collapsed .nav-link svg {
+    width: 22px;
+    height: 22px;
+    flex: 0 0 22px;
+  }
+
+  .desktop-navigation.is-collapsed .nav-text,
+  .desktop-navigation.is-collapsed .account-nav-copy,
+  .desktop-navigation.is-collapsed .navbar-version-row {
+    display: none !important;
+  }
+
+  .desktop-navigation.is-collapsed .nav-icon-badge {
+    position: absolute;
+    top: -5px;
+    right: -5px;
+    display: inline-flex;
+    min-width: 18px;
+    height: 18px;
+    align-items: center;
+    justify-content: center;
+    padding: 0 5px;
+    border: 1px solid rgba(255, 255, 255, 0.42);
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--primary-color), var(--primary-light-color));
+    color: #080a0f;
+    font-size: 10px;
+    font-weight: 950;
+    line-height: 1;
+  }
+
+  .desktop-navigation.is-collapsed .navbar-inline-footer {
+    align-items: center;
+    gap: 8px;
+    padding-bottom: 14px;
+  }
+
+  .desktop-navigation.is-collapsed .navbar-footer-account-row {
+    width: auto;
+    grid-template-columns: 46px;
+    justify-items: center;
+    gap: 8px;
+  }
+
+  .desktop-navigation.is-collapsed .account-navitem {
+    width: 46px;
+    min-height: 42px;
+    justify-content: center;
+    padding: 0 !important;
+    border-radius: 12px !important;
+  }
+
+  .desktop-navigation.is-collapsed .account-nav-avatar {
+    width: 30px;
+    height: 30px;
+    flex-basis: 30px;
+    border-width: 1px;
+  }
+
+  .desktop-navigation.is-collapsed .account-nav-avatar svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
 .profile-modal .modal-content {
   border: 1px solid rgba(var(--primary-rgb), 0.3);
   border-radius: 28px;
@@ -661,6 +845,44 @@
     color-mix(in srgb, var(--secondary-background-color) 96%, #000);
   color: #f8fafc;
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.55);
+}
+
+@media (min-width: 901px) {
+  .profile-modal {
+    position: fixed !important;
+    top: 50% !important;
+    left: 50% !important;
+    width: min(calc(100vw - 40px), 692px) !important;
+    max-width: 692px !important;
+    margin: 0 !important;
+    transform: translate(-50%, -50%) !important;
+  }
+
+  .profile-modal .modal-header {
+    min-height: 40px;
+    padding: 10px 14px;
+  }
+
+  .profile-modal .modal-body {
+    padding: 18px 22px;
+  }
+
+  .profile-modal .modal-footer {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 14px 22px 18px;
+  }
+
+  .profile-modal .modal-title {
+    font-size: 20px;
+  }
+
+  .profile-modal .btn {
+    min-height: 44px;
+    padding: 9px 16px;
+    font-size: 15px;
+  }
 }
 
 .profile-modal .modal-header,
@@ -673,6 +895,31 @@
   font-weight: 900;
 }
 
+.profile-modal-secondary-actions {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.profile-modal-secondary-actions .btn,
+.profile-modal .profile-logout-button {
+  width: 100%;
+  margin: 0 !important;
+  color: #f8fafc !important;
+  font-weight: 900 !important;
+}
+
+.profile-modal-secondary-actions .btn {
+  border-color: rgba(var(--primary-light-rgb), 0.38) !important;
+  background: rgba(255, 255, 255, 0.05) !important;
+}
+
+.profile-modal-secondary-actions .btn:hover {
+  border-color: rgba(var(--primary-light-rgb), 0.62) !important;
+  background: rgba(var(--primary-rgb), 0.18) !important;
+}
+
 .profile-modal .btn-close {
   filter: invert(1) grayscale(1);
   opacity: 0.75;
@@ -681,18 +928,22 @@
 .profile-modal-identity {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 16px;
+  gap: 13px;
+  padding: 13px;
   border: 1px solid rgba(255, 255, 255, 0.09);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.045);
 }
 
+.profile-modal-identity > div:last-child {
+  min-width: 0;
+}
+
 .profile-modal-avatar {
   display: flex;
-  width: 96px;
-  height: 96px;
-  flex: 0 0 96px;
+  width: 77px;
+  height: 77px;
+  flex: 0 0 77px;
   align-items: center;
   justify-content: center;
   border: 2px solid rgba(var(--primary-light-rgb), 0.44);
@@ -716,24 +967,30 @@
 
 .profile-modal-identity strong {
   display: block;
+  overflow: hidden;
   color: #f8fafc;
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 900;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .profile-modal-identity span {
   display: block;
-  margin-top: 4px;
+  overflow: hidden;
+  margin-top: 3px;
   color: #94a3b8;
-  font-size: 13px;
+  font-size: 15px;
   font-weight: 750;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .profile-avatar-upload {
   display: grid;
-  gap: 8px;
-  margin-top: 12px;
-  padding: 12px;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 10px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.035);
@@ -741,23 +998,23 @@
 
 .profile-avatar-upload span {
   color: #94a3b8;
-  font-size: 12px;
+  font-size: 13px;
 }
 
 .profile-avatar-upload input {
   width: 100%;
   color: #cbd5e1;
-  font-size: 12px;
+  font-size: 13px;
 }
 
 .profile-whats-new-button {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  gap: 10px;
+  gap: 8px;
   align-items: center;
   width: 100%;
-  margin-top: 12px;
-  padding: 12px;
+  margin-top: 10px;
+  padding: 10px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.18);
   border-radius: 12px;
   background: rgba(var(--primary-rgb), 0.1);
@@ -778,14 +1035,14 @@
 }
 
 .profile-whats-new-button strong {
-  font-size: 13px;
+  font-size: 15px;
   font-weight: 950;
 }
 
 .profile-whats-new-button small {
   margin-top: 2px;
   color: #94a3b8;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 750;
 }
 
@@ -796,9 +1053,9 @@
 
 .profile-font-panel {
   display: grid;
-  gap: 12px;
-  margin-top: 12px;
-  padding: 14px;
+  gap: 10px;
+  margin-top: 10px;
+  padding: 11px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.035);
@@ -807,27 +1064,27 @@
 .profile-font-header h3 {
   margin: 0;
   color: #f8fafc;
-  font-size: 15px;
+  font-size: 17px;
   font-weight: 900;
 }
 
 .profile-font-header span {
   display: block;
-  margin-top: 4px;
+  margin-top: 3px;
   color: #94a3b8;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
 }
 
 .profile-font-options {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
+  gap: 6px;
 }
 
 .profile-font-options button {
   display: grid;
-  gap: 4px;
+  gap: 3px;
   min-height: 82px;
   padding: 10px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.16);
@@ -845,22 +1102,22 @@
 
 .profile-font-options strong {
   color: #fff;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 850;
 }
 
 .profile-font-options span {
   color: #9fb0c7;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 650;
   line-height: 1.25;
 }
 
 .profile-theme-panel {
   display: grid;
-  gap: 14px;
-  margin-top: 12px;
-  padding: 14px;
+  gap: 11px;
+  margin-top: 10px;
+  padding: 11px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.035);
@@ -870,13 +1127,13 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
 }
 
 .profile-theme-header h3 {
   margin: 0;
   color: #f8fafc;
-  font-size: 15px;
+  font-size: 17px;
   font-weight: 900;
 }
 
@@ -884,7 +1141,7 @@
   display: block;
   margin-top: 3px;
   color: #94a3b8;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
 }
 
@@ -894,9 +1151,9 @@
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.04);
   color: #dbe3ef;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 850;
-  padding: 7px 10px;
+  padding: 5px 8px;
 }
 
 .profile-theme-reset:hover {
@@ -907,7 +1164,7 @@
 .profile-theme-select {
   display: grid;
   min-width: 0;
-  gap: 7px;
+  gap: 6px;
 }
 
 .profile-theme-select > span {
@@ -921,16 +1178,16 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   width: 100%;
   min-height: 38px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 10px;
   background: rgba(8, 12, 18, 0.72);
   color: #f8fafc;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 850;
-  padding: 0 12px;
+  padding: 0 10px;
   text-align: left;
 }
 
@@ -949,13 +1206,13 @@
 
 .profile-theme-select-arrow {
   color: #aebbd0 !important;
-  font-size: 14px !important;
+  font-size: 11px !important;
 }
 
 .profile-theme-preset-swatches {
   display: flex;
-  width: 48px;
-  height: 18px;
+  width: 38px;
+  height: 14px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 999px;
@@ -967,10 +1224,10 @@
 
 .profile-theme-select-menu {
   display: grid;
-  max-height: 188px;
-  gap: 6px;
+  max-height: 150px;
+  gap: 5px;
   overflow-y: auto;
-  padding: 7px;
+  padding: 6px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.18);
   border-radius: 12px;
   background: rgba(5, 8, 13, 0.92);
@@ -979,7 +1236,7 @@
 .profile-theme-select-menu button {
   grid-template-columns: auto minmax(0, 1fr);
   min-height: 36px;
-  padding: 0 10px;
+  padding: 0 8px;
   border-color: transparent;
 }
 
@@ -992,13 +1249,13 @@
 .profile-theme-fields {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
+  gap: 8px;
 }
 
 .profile-theme-field {
   display: grid;
   min-width: 0;
-  gap: 7px;
+  gap: 6px;
 }
 
 .profile-theme-field > span {
@@ -1010,14 +1267,14 @@
 .profile-theme-input {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
 }
 
 .profile-theme-input input[type="color"] {
-  width: 42px;
+  width: 34px;
   height: 34px;
-  flex: 0 0 42px;
+  flex: 0 0 34px;
   padding: 2px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 10px;
@@ -1032,9 +1289,9 @@
   border-radius: 10px;
   background: rgba(0, 0, 0, 0.16);
   color: #e2e8f0;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 850;
-  padding: 0 8px;
+  padding: 0 6px;
   text-transform: uppercase;
 }
 
@@ -1047,7 +1304,7 @@
 
 @media (max-width: 900px), (hover: none) and (pointer: coarse) {
   .profile-modal {
-    width: min(100vw - 18px, 460px) !important;
+    width: min(100vw - 18px, 692px) !important;
     margin: 8px auto !important;
   }
 
@@ -1081,6 +1338,10 @@
   .profile-modal .modal-footer > * {
     width: 100%;
     margin: 0 !important;
+  }
+
+  .profile-modal-secondary-actions {
+    grid-column: 1 / -1;
   }
 
   .profile-logout-button {
@@ -1198,18 +1459,7 @@
     padding: 8px 14px !important;
   }
 
-  .navbar-inline-footer .footer-logout {
-    min-height: 58px !important;
-    grid-column: 1 / -1 !important;
-    grid-template-columns: 30px minmax(0, 1fr) !important;
-    grid-template-rows: 1fr !important;
-    justify-items: start !important;
-    justify-content: stretch !important;
-    padding: 0 16px !important;
-    text-align: left !important;
-  }
-
-  .navbar-inline-footer .version {
+  .navbar-version-row {
     grid-column: 1 / -1 !important;
     width: 100% !important;
     margin: 0 !important;

--- a/apps/web/src/pages/css/settings/backups.css
+++ b/apps/web/src/pages/css/settings/backups.css
@@ -2,7 +2,7 @@
 
 .backup-page {
   display: grid;
-  gap: 16px;
+  gap: 12px;
   color: #f8fafc;
 }
 
@@ -22,9 +22,9 @@
   display: flex;
   align-items: end;
   justify-content: space-between;
-  gap: 18px;
-  border-radius: 18px;
-  padding: 18px;
+  gap: 14px;
+  border-radius: 8px;
+  padding: 14px;
 }
 
 .backup-hero span,
@@ -32,25 +32,27 @@
 .backup-summary-grid span {
   display: block;
   color: #9db5d4;
-  font-size: 12px;
-  font-weight: 950;
-  letter-spacing: 0.14em;
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
 .backup-hero h1 {
-  margin: 5px 0 8px !important;
+  margin: 4px 0 6px !important;
   color: #fff;
-  font-size: clamp(2.2rem, 4vw, 4.4rem);
-  font-weight: 950;
-  line-height: 0.92;
+  font-size: clamp(1.55rem, 2.2vw, 2.6rem);
+  font-weight: 760;
+  line-height: 1;
 }
 
 .backup-hero p {
-  max-width: 720px;
+  max-width: 620px;
   margin: 0;
   color: #aab8cc;
-  font-weight: 750;
+  font-size: 13px;
+  font-weight: 560;
+  line-height: 1.35;
 }
 
 .backup-hero-actions,
@@ -67,7 +69,7 @@
 .backup-hero-actions {
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 10px;
+  gap: 8px;
 }
 
 .backup-hero-actions .btn,
@@ -76,16 +78,17 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 7px;
-  min-height: 38px;
-  border-radius: 10px !important;
-  font-weight: 900 !important;
+  gap: 6px;
+  min-height: 32px;
+  border-radius: 8px !important;
+  font-size: 12px;
+  font-weight: 760 !important;
 }
 
 .backup-upload-button {
   cursor: pointer;
   border: 1px solid rgba(var(--primary-light-rgb), 0.35);
-  padding: 0 14px;
+  padding: 0 11px;
   color: #f8fafc;
   background: rgba(var(--primary-light-rgb), 0.12);
 }
@@ -96,38 +99,38 @@
 
 .backup-summary-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 10px;
 }
 
 .backup-summary-grid article {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  gap: 14px;
+  gap: 11px;
   min-width: 0;
-  border-radius: 15px;
-  padding: 14px;
+  border-radius: 8px;
+  padding: 11px;
 }
 
 .backup-summary-grid svg {
-  width: 36px;
-  height: 36px;
+  width: 28px;
+  height: 28px;
   color: var(--primary-light-color);
 }
 
 .backup-summary-grid article > div {
   display: grid;
   align-content: center;
-  gap: 4px;
+  gap: 3px;
   min-width: 0;
 }
 
 .backup-summary-grid strong {
   display: block;
   color: #fff;
-  font-size: 28px;
-  font-weight: 950;
+  font-size: 20px;
+  font-weight: 760;
   line-height: 1;
   white-space: nowrap;
 }
@@ -136,26 +139,26 @@
   display: block;
   overflow: hidden;
   color: #9fadbf;
-  font-size: 12px;
-  font-weight: 800;
+  font-size: 10px;
+  font-weight: 650;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .backup-panel {
   display: grid;
-  gap: 14px;
-  border-radius: 18px;
-  padding: 16px;
+  gap: 11px;
+  border-radius: 8px;
+  padding: 12px;
 }
 
 .backup-panel-heading {
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
 }
 
 .backup-panel-heading > div {
-  gap: 10px;
+  gap: 8px;
 }
 
 .backup-panel-heading svg {
@@ -165,22 +168,22 @@
 .backup-panel-heading h2 {
   margin: 0 !important;
   color: #fff;
-  font-size: 24px;
-  font-weight: 950;
+  font-size: 18px;
+  font-weight: 760;
 }
 
 .backup-table-chip-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 9px;
+  gap: 7px;
 }
 
 .backup-table-chip {
-  gap: 8px;
-  min-height: 42px;
+  gap: 6px;
+  min-height: 32px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.28);
   border-radius: 999px;
-  padding: 0 12px;
+  padding: 0 9px;
   color: #f8fafc;
   background: rgba(var(--primary-light-rgb), 0.12);
 }
@@ -192,36 +195,37 @@
 }
 
 .backup-table-chip span {
-  font-weight: 950;
+  font-size: 12px;
+  font-weight: 760;
 }
 
 .backup-table-chip small {
   color: #9fadbf;
-  font-size: 11px;
-  font-weight: 850;
+  font-size: 9px;
+  font-weight: 650;
 }
 
 .backup-file-grid {
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 .backup-file-card {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 14px;
-  border-radius: 15px;
-  padding: 13px;
+  gap: 11px;
+  border-radius: 8px;
+  padding: 10px;
 }
 
 .backup-file-icon {
   display: grid;
-  width: 48px;
-  height: 48px;
+  width: 38px;
+  height: 38px;
   place-items: center;
   border: 1px solid rgba(var(--primary-light-rgb), 0.25);
-  border-radius: 14px;
+  border-radius: 8px;
   color: var(--primary-light-color);
   background: rgba(var(--primary-light-rgb), 0.11);
 }
@@ -232,48 +236,48 @@
 
 .backup-file-main h3 {
   overflow: hidden;
-  margin: 0 0 6px !important;
+  margin: 0 0 5px !important;
   color: #fff;
-  font-size: 15px;
-  font-weight: 950;
+  font-size: 13px;
+  font-weight: 760;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .backup-file-meta {
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   color: #9fadbf;
-  font-size: 12px;
-  font-weight: 800;
+  font-size: 10px;
+  font-weight: 650;
 }
 
 .backup-file-meta span {
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
-  padding: 4px 8px;
+  padding: 3px 7px;
   background: rgba(255, 255, 255, 0.035);
 }
 
 .backup-file-actions {
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 6px;
 }
 
 .backup-file-actions .btn {
-  min-height: 34px;
-  padding: 0 10px !important;
-  font-size: 12px;
+  min-height: 30px;
+  padding: 0 8px !important;
+  font-size: 11px;
 }
 
 .backup-empty-state {
   display: grid;
-  min-height: 180px;
+  min-height: 132px;
   place-items: center;
-  gap: 8px;
-  border-radius: 15px;
-  padding: 24px;
+  gap: 6px;
+  border-radius: 8px;
+  padding: 18px;
   color: #aab7c8;
   text-align: center;
 }
@@ -284,8 +288,8 @@
 
 .backup-empty-state strong {
   color: #fff;
-  font-size: 18px;
-  font-weight: 950;
+  font-size: 14px;
+  font-weight: 760;
 }
 
 @media (max-width: 920px) {

--- a/apps/web/src/pages/css/settings/settings.css
+++ b/apps/web/src/pages/css/settings/settings.css
@@ -5,7 +5,11 @@
   grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
   align-items: start;
   gap: 22px;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
   min-height: 0;
+  overflow-x: hidden;
   padding: 28px clamp(18px, 3vw, 42px) 48px;
   background:
     radial-gradient(circle at 15% 0%, rgba(var(--primary-rgb), 0.18), transparent 32%),
@@ -47,32 +51,71 @@
   top: 18px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
+  align-self: start;
+  width: 100%;
+  min-width: 0;
   margin-bottom: 0;
   padding: 8px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.18);
   border-radius: 16px;
   background: rgba(12, 15, 22, 0.72);
+  contain: layout paint;
+}
+
+.settings-sidebar-group {
+  display: grid;
+  gap: 4px;
+}
+
+.settings-sidebar-group + .settings-sidebar-group {
+  margin-top: 8px;
+}
+
+.settings-sidebar-category {
+  display: block;
+  margin: 7px 8px 6px;
+  color: rgba(var(--primary-light-rgb), 0.82);
+  font-size: 10px;
+  font-weight: 950;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.settings-sidebar-group:first-child .settings-sidebar-category {
+  margin-top: 2px;
 }
 
 .settings > .nav-pills .nav-link {
   display: flex !important;
+  box-sizing: border-box;
   width: 100%;
-  min-height: 42px;
+  height: 38px;
+  min-height: 38px;
   align-items: center;
   justify-content: flex-start;
   border-radius: 11px !important;
+  padding: 0 12px !important;
   color: #cbd5e1 !important;
   font-size: 13px;
   font-weight: 850;
+  line-height: 1;
   text-align: left;
+  transition: background-color 160ms ease, color 160ms ease;
 }
 
 .settings-tab-title {
   display: inline-flex;
+  flex: 1 1 auto;
   align-items: center;
   gap: 7px;
   min-width: 0;
+  line-height: 1;
+}
+
+.settings-tab-title svg {
+  flex: 0 0 auto;
 }
 
 .settings-tab-title span {
@@ -87,12 +130,211 @@
 
 .settings > .nav-pills .nav-link.active {
   background: linear-gradient(90deg, rgba(var(--primary-rgb), 0.9), rgba(var(--primary-light-rgb), 0.62)) !important;
+  background-color: var(--primary-color) !important;
   color: #fff !important;
 }
 
+.settings > .nav-pills .nav-link:not(.active):hover,
+.settings > .nav-pills .nav-link:not(.active):focus-visible {
+  background: rgba(255, 255, 255, 0.045) !important;
+  background-color: rgba(255, 255, 255, 0.045) !important;
+  color: #f8fafc !important;
+}
+
+.nav-order-settings {
+  display: grid;
+  gap: 14px;
+  margin-top: 18px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.18);
+  border-radius: 16px;
+  padding: 18px;
+  background:
+    linear-gradient(135deg, rgba(var(--primary-rgb), 0.14), rgba(10, 14, 22, 0.76)),
+    rgba(12, 15, 22, 0.72);
+}
+
+.nav-order-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.nav-order-header h2 {
+  margin: 0;
+  color: #f8fafc;
+  font-size: 22px;
+  font-weight: 900;
+}
+
+.nav-order-header p {
+  margin: 4px 0 0;
+  color: #9aa7bb;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.nav-order-locked {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.nav-order-locked span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: rgba(7, 10, 16, 0.55);
+  color: #cbd5e1;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.nav-order-locked svg {
+  color: var(--primary-light-color);
+}
+
+.nav-order-list {
+  display: grid;
+  gap: 8px;
+}
+
+.nav-order-row {
+  display: grid;
+  grid-template-columns: 24px 28px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 48px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.16);
+  border-radius: 12px;
+  padding: 9px 10px;
+  background: rgba(8, 12, 19, 0.78);
+  color: #f8fafc;
+  cursor: grab;
+  transition:
+    border-color 0.18s ease,
+    background 0.18s ease,
+    opacity 0.18s ease;
+}
+
+.nav-order-row.is-hidden {
+  opacity: 0.66;
+}
+
+.nav-order-row:hover,
+.nav-order-row:focus-within {
+  border-color: rgba(var(--primary-light-rgb), 0.38);
+  background: rgba(var(--primary-rgb), 0.14);
+}
+
+.nav-order-row.is-dragging {
+  opacity: 0.55;
+}
+
+.nav-order-drag,
+.nav-order-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #cbd5e1;
+}
+
+.nav-order-icon svg {
+  width: 18px;
+  height: 18px;
+  color: var(--primary-light-color);
+}
+
+.nav-order-row strong {
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 850;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nav-order-visibility {
+  display: inline-grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  margin: 0;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.28);
+  border-radius: 8px;
+  background: rgba(var(--primary-rgb), 0.13);
+  color: #f8fafc;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease, color 0.18s ease, opacity 0.18s ease;
+}
+
+.nav-order-visibility:hover,
+.nav-order-visibility:focus-visible {
+  border-color: rgba(var(--primary-light-rgb), 0.58);
+  background: rgba(var(--primary-rgb), 0.25);
+  color: #ffffff;
+}
+
+.nav-order-visibility[aria-pressed="false"] {
+  border-color: rgba(148, 163, 184, 0.24);
+  background: rgba(255, 255, 255, 0.04);
+  color: #94a3b8;
+}
+
+.nav-order-visibility svg {
+  width: 18px;
+  height: 18px;
+}
+
+.nav-order-actions {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.nav-order-actions button {
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #f8fafc;
+}
+
+.nav-order-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+@media (max-width: 720px) {
+  .nav-order-header {
+    flex-direction: column;
+  }
+
+  .nav-order-row {
+    grid-template-columns: 24px 28px minmax(0, 1fr) auto;
+  }
+
+  .nav-order-visibility {
+    grid-column: 3 / -1;
+  }
+
+  .nav-order-actions {
+    grid-column: 3 / -1;
+    justify-content: flex-start;
+  }
+}
+
 .settings .tab-content {
+  width: 100%;
   min-width: 0;
+  max-width: 100%;
   display: block;
+  overflow-x: hidden;
   margin-top: 0;
   padding: 0;
   min-height: 0;
@@ -104,6 +346,9 @@
 
 .settings > .tab-content > .tab-pane {
   display: none !important;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
   margin: 0 !important;
   padding: 0 !important;
   min-height: 0 !important;
@@ -118,6 +363,8 @@
 }
 
 .settings .tab-pane > * {
+  min-width: 0;
+  max-width: 100%;
   min-height: 0;
   align-self: start;
 }
@@ -155,7 +402,46 @@
 }
 
 .settings-import-pane {
+  width: 100%;
   min-width: 0;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+.settings :is(
+  .settings-form,
+  .libraries,
+  .library-display-settings,
+  .libraries-container,
+  .backup-page,
+  .backup-panel,
+  .backup-file-grid,
+  .webhooks-settings,
+  .webhook-builder,
+  .webhook-destination-grid,
+  .notification-settings,
+  .notification-panel,
+  .newsletter-settings,
+  .newsletter-settings-grid,
+  .newsletter-layout,
+  .health-settings,
+  .health-panel,
+  .legacy-import-page,
+  .legacy-import-panel,
+  .legacy-import-review,
+  .jellyfin-admin-settings,
+  .jellyfin-admin-section,
+  .server-management,
+  .tasks,
+  .tasks-grid
+) {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.settings :is(.health-panel, .settings-logs-table, .legacy-import-review, .backup-panel) {
+  overflow-x: auto;
 }
 
 .app-error-boundary {
@@ -338,6 +624,329 @@
   background: rgba(5, 8, 13, 0.72);
 }
 
+.general-settings-page {
+  display: grid;
+  gap: 16px;
+}
+
+.general-settings-page .settings-section-header {
+  margin-bottom: 0;
+}
+
+.general-settings-content {
+  display: grid;
+  grid-template-columns: minmax(420px, 0.92fr) minmax(340px, 0.72fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.general-settings-card {
+  display: grid;
+  gap: 16px;
+  margin-top: 0;
+}
+
+.general-settings-card.is-single-form {
+  max-width: none;
+}
+
+.general-settings-card.is-single-form .row {
+  grid-template-columns: minmax(120px, 170px) minmax(0, 1fr);
+}
+
+.general-settings-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.general-settings-card-head h3 {
+  margin: 0 !important;
+  color: #f8fafc;
+  font-size: 18px;
+  font-weight: 760 !important;
+}
+
+.general-settings-card-head p {
+  margin: 4px 0 0;
+  color: #9da8b8;
+  font-size: 13px;
+  font-weight: 560;
+}
+
+.general-settings-card-head svg {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  color: var(--primary-light-color);
+}
+
+.general-settings-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.general-settings-pending {
+  min-width: 0;
+  color: var(--primary-light-color);
+  font-size: 12px;
+  font-weight: 720;
+}
+
+.general-form-section {
+  display: grid;
+  gap: 12px;
+  padding-top: 2px;
+}
+
+.general-form-section + .general-form-section {
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.general-form-section h4 {
+  margin: 0 !important;
+  color: #cbd5e1;
+  font-size: 12px;
+  font-weight: 760 !important;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.general-settings-content .nav-order-settings {
+  margin-top: 0;
+}
+
+.general-theme-swatches {
+  display: flex;
+  width: 42px;
+  height: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+}
+
+.general-theme-swatches i {
+  flex: 1;
+}
+
+.general-theme-selected {
+  display: grid;
+  gap: 10px;
+  max-width: 100%;
+  padding: 10px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 16% 0%, rgba(var(--primary-rgb), 0.18), transparent 34%),
+    rgba(255, 255, 255, 0.035);
+}
+
+.general-theme-selected > div:first-child {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.general-theme-selected strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #f8fafc;
+  font-size: 13px;
+  font-weight: 720;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.general-theme-custom-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.general-theme-custom-control {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  min-width: 0;
+}
+
+.general-theme-custom-control span {
+  color: #9da8b8;
+  font-size: 11px;
+  font-weight: 760;
+}
+
+.general-theme-custom-control div {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 6px;
+  min-width: 0;
+}
+
+.general-theme-custom-control input[type="color"] {
+  width: 36px;
+  height: 34px;
+  padding: 2px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(5, 8, 13, 0.68);
+  cursor: pointer;
+}
+
+.general-theme-custom-control input[type="text"] {
+  min-width: 0;
+  height: 34px;
+  padding: 0 9px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background: rgba(5, 8, 13, 0.58);
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 720;
+}
+
+.general-theme-preview {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  min-height: 126px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--preview-primary) 34%, transparent);
+  border-radius: 8px;
+  background: var(--preview-background);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.general-theme-preview-sidebar {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  padding: 12px 10px;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  background: color-mix(in srgb, var(--preview-surface) 72%, #000 28%);
+}
+
+.general-theme-preview-sidebar span,
+.general-theme-preview-sidebar i {
+  display: block;
+  border-radius: 999px;
+}
+
+.general-theme-preview-sidebar span {
+  width: 24px;
+  height: 24px;
+  background: linear-gradient(135deg, var(--preview-primary), var(--preview-secondary));
+}
+
+.general-theme-preview-sidebar i {
+  width: 30px;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.general-theme-preview-sidebar i:first-of-type {
+  background: color-mix(in srgb, var(--preview-primary) 72%, #fff 10%);
+}
+
+.general-theme-preview-main {
+  display: grid;
+  gap: 9px;
+  padding: 12px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--preview-primary) 16%, transparent), transparent 52%),
+    var(--preview-background);
+}
+
+.general-theme-preview-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.general-theme-preview-top strong {
+  color: #f8fafc;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.general-theme-preview-top span {
+  color: color-mix(in srgb, var(--preview-secondary) 72%, #fff 16%);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.general-theme-preview-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--preview-surface) 88%, #fff 4%);
+}
+
+.general-theme-preview-card b,
+.general-theme-preview-card small {
+  display: block;
+}
+
+.general-theme-preview-card b {
+  color: #f8fafc;
+  font-size: 12px;
+}
+
+.general-theme-preview-card small {
+  margin-top: 2px;
+  color: #aeb9c9;
+  font-size: 10px;
+}
+
+.general-theme-preview-card button {
+  flex: 0 0 auto;
+  min-width: 54px;
+  min-height: 28px;
+  border: 1px solid color-mix(in srgb, var(--preview-primary) 70%, #fff 12%);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--preview-primary) 32%, transparent);
+  color: #f8fafc;
+  font-size: 11px;
+  font-weight: 800;
+  pointer-events: none;
+}
+
+.general-theme-preview-list {
+  display: grid;
+  gap: 6px;
+}
+
+.general-theme-preview-list span {
+  height: 7px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.general-theme-preview-list span:nth-child(1) {
+  width: 88%;
+  background: linear-gradient(90deg, var(--preview-primary), var(--preview-secondary));
+}
+
+.general-theme-preview-list span:nth-child(2) {
+  width: 68%;
+}
+
+.general-theme-preview-list span:nth-child(3) {
+  width: 78%;
+}
+
 .settings-chip {
   display: inline-flex;
   align-items: center;
@@ -354,9 +963,330 @@
   text-transform: uppercase;
 }
 
+.kiosk-settings-page {
+  display: grid;
+  gap: 16px;
+}
+
+.kiosk-settings-hero,
+.kiosk-settings-panel {
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(var(--primary-rgb), 0.08), rgba(var(--secondary-rgb), 0.035)),
+    rgba(17, 22, 30, 0.84);
+}
+
+.kiosk-settings-hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 18px;
+}
+
+.kiosk-settings-hero span,
+.kiosk-widget-heading span,
+.kiosk-settings-grid label > span {
+  color: var(--primary-light-color);
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.kiosk-settings-hero h2,
+.kiosk-widget-heading h3 {
+  margin: 4px 0 0;
+  color: #f8fafc;
+  font-weight: 780;
+  letter-spacing: 0;
+}
+
+.kiosk-settings-hero h2 {
+  font-size: clamp(28px, 3vw, 42px);
+  line-height: 1;
+}
+
+.kiosk-settings-hero p {
+  max-width: 720px;
+  margin: 9px 0 0;
+  color: #9da8b8;
+  font-size: 13px;
+  font-weight: 560;
+}
+
+.kiosk-settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.kiosk-settings-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.kiosk-settings-panel {
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+}
+
+.kiosk-settings-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.kiosk-settings-grid label {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  margin: 0;
+}
+
+.kiosk-settings-grid input,
+.kiosk-settings-grid select,
+.kiosk-widget-list select {
+  width: 100%;
+  min-width: 0;
+  min-height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background: rgba(5, 8, 13, 0.58);
+  color: #f8fafc;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.kiosk-settings-toggle button {
+  min-height: 38px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.045);
+  color: #cbd5e1;
+  font-weight: 740;
+}
+
+.kiosk-settings-toggle button.is-enabled {
+  border-color: rgba(var(--primary-light-rgb), 0.38);
+  background: rgba(var(--primary-rgb), 0.18);
+  color: #f8fafc;
+}
+
+.kiosk-widget-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.kiosk-widget-heading h3 {
+  font-size: 22px;
+}
+
+.kiosk-widget-heading small {
+  color: #aeb9c9;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.kiosk-widget-list {
+  display: grid;
+  gap: 8px;
+}
+
+.kiosk-widget-groups {
+  display: grid;
+  gap: 16px;
+}
+
+.kiosk-widget-group {
+  display: grid;
+  gap: 8px;
+}
+
+.kiosk-widget-group h4 {
+  margin: 0 !important;
+  color: #f8fafc;
+  font-size: 15px;
+  font-weight: 760 !important;
+}
+
+.kiosk-widget-list article {
+  display: grid;
+  grid-template-columns: 58px 36px minmax(0, 1fr) minmax(140px, 180px) auto;
+  gap: 9px;
+  align-items: center;
+  min-width: 0;
+  padding: 9px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background: rgba(5, 8, 13, 0.34);
+}
+
+.kiosk-widget-list article.is-hidden {
+  opacity: 0.58;
+}
+
+.kiosk-widget-order {
+  display: inline-grid;
+  min-height: 28px;
+  place-items: center;
+  padding: 0 8px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.22);
+  border-radius: 8px;
+  background: rgba(var(--primary-rgb), 0.12);
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.kiosk-widget-list article > button,
+.kiosk-widget-list article > div button {
+  display: inline-grid;
+  min-width: 34px;
+  min-height: 34px;
+  place-items: center;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.22);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.045);
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 740;
+}
+
+.kiosk-widget-list article > div {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.kiosk-widget-list article > div button:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+.kiosk-widget-list strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #f8fafc;
+  font-size: 14px;
+  font-weight: 760;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kiosk-widget-empty {
+  margin: 0;
+  padding: 14px;
+  border: 1px dashed rgba(var(--primary-light-rgb), 0.2);
+  border-radius: 8px;
+  color: #9da8b8;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.security-page {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
+.security-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
+  gap: 18px;
+  align-items: stretch;
+  padding: 18px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.18);
+  border-radius: 16px;
+  background:
+    linear-gradient(135deg, rgba(var(--primary-rgb), 0.16), rgba(8, 12, 19, 0.82)),
+    rgba(12, 15, 22, 0.7);
+}
+
+.security-hero span,
+.security-auth-header > div > span {
+  color: var(--primary-light-color);
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.security-hero h1 {
+  margin: 5px 0 8px;
+  color: #fff;
+  font-size: clamp(34px, 3.8vw, 54px);
+  font-weight: 950;
+  line-height: 0.98;
+}
+
+.security-hero p {
+  max-width: 680px;
+  margin: 0;
+  color: #a9b5c7;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.55;
+}
+
+.security-current-stack {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.security-current-stack article {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 5px 10px;
+  align-items: center;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.16);
+  border-radius: 12px;
+  background: rgba(5, 8, 13, 0.58);
+}
+
+.security-current-stack svg {
+  grid-row: span 2;
+  color: var(--primary-light-color);
+}
+
+.security-current-stack span {
+  overflow: hidden;
+  color: #8fa0b8;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.security-current-stack strong {
+  overflow: hidden;
+  color: #f8fafc;
+  font-size: 13px;
+  font-weight: 900;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.security-status-alert {
+  margin: 0;
+  border-radius: 12px;
+  font-weight: 800;
+}
+
 .security-auth-form {
   display: grid;
   gap: 18px;
+}
+
+.security-privacy-form {
+  margin-bottom: 0;
 }
 
 .security-auth-header {
@@ -393,8 +1323,12 @@
 
 .security-auth-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
   gap: 12px;
+}
+
+.security-privacy-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 210px), 1fr));
 }
 
 .security-auth-card {
@@ -411,6 +1345,15 @@
     rgba(5, 8, 13, 0.54);
   color: #dce6f4;
   text-align: left;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+
+.security-auth-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(var(--primary-light-rgb), 0.36);
+  background:
+    linear-gradient(145deg, rgba(var(--primary-rgb), 0.14), rgba(255, 255, 255, 0.028)),
+    rgba(5, 8, 13, 0.7);
 }
 
 .security-auth-card svg {
@@ -447,6 +1390,19 @@
   border: 1px solid rgba(var(--primary-light-rgb), 0.16);
   border-radius: 15px;
   background: rgba(255, 255, 255, 0.032);
+}
+
+.security-auth-panel .row:last-child {
+  margin-bottom: 0 !important;
+}
+
+.security-form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.security-form-actions .btn {
+  min-width: 180px;
 }
 
 .security-users-link {
@@ -1011,7 +1967,7 @@
 .newsletter-layout,
 .newsletter-settings-grid {
   display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(380px, 0.8fr);
+  grid-template-columns: minmax(0, 0.95fr) minmax(min(100%, 320px), 0.8fr);
   gap: 14px;
   align-items: start;
 }
@@ -1282,7 +2238,7 @@
 
 .notification-mode-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 180px), 1fr));
   gap: 10px;
 }
 
@@ -2011,6 +2967,14 @@
 }
 
 @media (max-width: 1180px) {
+  .security-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .security-current-stack {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .settings {
     display: block;
     overflow-x: hidden;
@@ -2306,6 +3270,31 @@
 }
 
 @media (max-width: 640px) {
+  .security-page {
+    gap: 12px;
+  }
+
+  .security-hero {
+    padding: 13px;
+    border-radius: 13px;
+  }
+
+  .security-hero h1 {
+    font-size: 28px;
+  }
+
+  .security-hero p {
+    font-size: 12px;
+  }
+
+  .security-current-stack {
+    grid-template-columns: 1fr;
+  }
+
+  .security-form-actions .btn {
+    width: 100%;
+  }
+
   .settings {
     padding: 8px 10px calc(env(safe-area-inset-bottom, 0px) + 34px);
     background:
@@ -2755,6 +3744,15 @@
   font-weight: 680 !important;
 }
 
+.settings > .nav-pills .nav-link {
+  box-sizing: border-box;
+  height: 38px;
+  min-height: 38px;
+  padding: 0 12px !important;
+  line-height: 1;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
 .settings > .nav-pills .nav-link.active,
 .settings-import-tabs .nav-link.active,
 .settings-form .input-group > .btn,
@@ -2982,24 +3980,33 @@
 
 .server-task-list {
   display: grid;
-  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr));
+  gap: 12px;
 }
 
 .server-task-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 12px;
-  align-items: center;
-  min-height: 76px;
-  padding: 12px;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: stretch;
+  min-height: 214px;
+  padding: 14px;
   border: 1px solid var(--surface-border-color);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.035);
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(var(--primary-rgb), 0.12), transparent 42%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.024)),
+    rgba(9, 12, 19, 0.88);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .server-task-row.is-running {
   border-color: rgba(96, 165, 250, 0.42);
-  background: rgba(96, 165, 250, 0.08);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(96, 165, 250, 0.22), transparent 42%),
+    linear-gradient(180deg, rgba(96, 165, 250, 0.1), rgba(255, 255, 255, 0.024)),
+    rgba(9, 12, 19, 0.9);
 }
 
 .server-task-row.is-success {
@@ -3008,22 +4015,34 @@
 
 .server-task-row.is-error {
   border-color: rgba(248, 113, 113, 0.42);
-  background: rgba(127, 29, 29, 0.12);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(248, 113, 113, 0.22), transparent 42%),
+    linear-gradient(180deg, rgba(127, 29, 29, 0.16), rgba(255, 255, 255, 0.02)),
+    rgba(9, 12, 19, 0.9);
 }
 
 .server-task-row strong {
-  display: block;
-  margin-top: 2px;
+  display: -webkit-box;
+  margin-top: 6px;
+  overflow: hidden;
   color: #f8fafc;
-  font-size: 15px;
-  font-weight: 760;
+  font-size: 17px;
+  font-weight: 860;
+  line-height: 1.18;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .server-task-row p {
-  margin: 4px 0 0;
+  display: -webkit-box;
+  min-height: 54px;
+  margin: 8px 0 0;
+  overflow: hidden;
   color: #9aa7bb;
   font-size: 13px;
   line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 }
 
 .server-task-row small {
@@ -3034,6 +4053,7 @@
   color: #7f8da3;
   font-size: 12px;
   font-weight: 650;
+  line-height: 1.2;
 }
 
 .server-task-row small svg {
@@ -3041,16 +4061,50 @@
 }
 
 .server-task-actions {
-  display: inline-flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
+  align-self: end;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.075);
 }
 
 .server-task-actions em {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  min-height: 28px;
+  align-items: center;
+  padding: 0 9px;
+  overflow: hidden;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.2);
+  border-radius: 999px;
+  background: rgba(var(--primary-rgb), 0.12);
   color: #b6c1d2;
   font-size: 12px;
   font-style: normal;
   font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.server-task-row.is-running .server-task-actions em {
+  border-color: rgba(96, 165, 250, 0.34);
+  background: rgba(96, 165, 250, 0.14);
+  color: #bfdbfe;
+}
+
+.server-task-row.is-success .server-task-actions em {
+  border-color: rgba(52, 211, 153, 0.3);
+  background: rgba(6, 78, 59, 0.16);
+  color: #a7f3d0;
+}
+
+.server-task-row.is-error .server-task-actions em {
+  border-color: rgba(248, 113, 113, 0.34);
+  background: rgba(127, 29, 29, 0.18);
+  color: #fecaca;
 }
 
 .server-management-empty {
@@ -3246,19 +4300,33 @@
 
 .jellyfin-device-list {
   display: grid;
-  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
+  gap: 12px;
 }
 
 .jellyfin-device-row {
   display: grid;
-  grid-template-columns: 44px minmax(0, 1fr) minmax(180px, auto);
-  gap: 12px;
-  align-items: center;
-  min-height: 72px;
-  padding: 12px;
+  grid-template-columns: 48px minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 12px 14px;
+  align-items: start;
+  min-height: 176px;
+  padding: 14px;
   border: 1px solid var(--surface-border-color);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.035);
+  background:
+    linear-gradient(145deg, rgba(var(--primary-rgb), 0.08), rgba(255, 255, 255, 0.025)),
+    rgba(255, 255, 255, 0.035);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.18);
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.jellyfin-device-row:hover {
+  border-color: rgba(var(--primary-light-rgb), 0.34);
+  background:
+    linear-gradient(145deg, rgba(var(--primary-rgb), 0.13), rgba(255, 255, 255, 0.032)),
+    rgba(255, 255, 255, 0.045);
+  transform: translateY(-1px);
 }
 
 .jellyfin-device-icon,
@@ -3269,17 +4337,27 @@
 }
 
 .jellyfin-device-icon {
-  width: 42px;
-  height: 42px;
+  width: 48px;
+  height: 48px;
   border: 1px solid rgba(var(--primary-light-rgb), 0.18);
   border-radius: 8px;
   background: rgba(var(--primary-rgb), 0.12);
 }
 
 .jellyfin-device-icon svg {
-  width: 22px;
-  height: 22px;
+  width: 26px;
+  height: 26px;
   fill: var(--platform-icon-color, var(--primary-light-color));
+}
+
+.jellyfin-device-icon img {
+  width: 26px;
+  height: 26px;
+  object-fit: contain;
+}
+
+.jellyfin-device-row > div:nth-child(2) {
+  min-width: 0;
 }
 
 .jellyfin-device-row span,
@@ -3297,7 +4375,7 @@
   margin-top: 2px;
   overflow: hidden;
   color: #f8fafc;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 760;
   line-height: 1.15;
   text-overflow: ellipsis;
@@ -3317,16 +4395,28 @@
 }
 
 .jellyfin-device-meta {
-  text-align: right;
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 4px;
+  align-self: end;
+  min-width: 0;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  text-align: left;
 }
 
 .jellyfin-device-meta span {
   color: #9aa7bb;
 }
 
+.jellyfin-device-meta strong {
+  margin-top: 0;
+  font-size: 13px;
+}
+
 .jellyfin-plugin-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
   gap: 10px;
 }
 
@@ -3436,19 +4526,31 @@
 }
 
 @media (max-width: 1100px) {
+  .general-settings-content {
+    grid-template-columns: 1fr;
+  }
+
+  .kiosk-settings-hero {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .kiosk-settings-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .server-management-grid {
     grid-template-columns: 1fr;
   }
 
   .jellyfin-plugin-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
   }
 }
 
 @media (max-width: 720px) {
   .server-management-header,
-  .server-management-section-heading,
-  .server-task-row {
+  .server-management-section-heading {
     grid-template-columns: 1fr;
   }
 
@@ -3469,12 +4571,7 @@
   }
 
   .jellyfin-device-row {
-    grid-template-columns: 42px minmax(0, 1fr);
-  }
-
-  .jellyfin-device-meta {
-    grid-column: 2;
-    text-align: left;
+    min-height: 158px;
   }
 
   .jellyfin-plugin-card {
@@ -3484,5 +4581,24 @@
   .jellyfin-plugin-art {
     width: 70px;
     height: 48px;
+  }
+}
+
+@media (max-width: 560px) {
+  .general-settings-actions {
+    justify-content: stretch;
+  }
+
+  .general-settings-actions .btn {
+    width: 100%;
+  }
+
+  .kiosk-settings-grid,
+  .kiosk-widget-list article {
+    grid-template-columns: 1fr;
+  }
+
+  .kiosk-widget-list article > div {
+    justify-content: flex-start;
   }
 }

--- a/apps/web/src/pages/css/settings/version.css
+++ b/apps/web/src/pages/css/settings/version.css
@@ -35,24 +35,3 @@
     font-size: 12px;
     font-weight: 800;
 }
-
-.nav-pills > .nav-item , .nav-pills > .nav-item > .nav-link
-{
-    color: white !important;
-}
-
-.nav-pills > .nav-item .active  
-{
-    background-color: var(--primary-color) !important;
-    color: white !important;
-}
-
-.nav-pills > .nav-item :hover
-{
-    background-color: var(--primary-color) !important;
-}
-
-.nav-pills > .nav-item  .active> .nav-link
-{
-   color: white;
-}

--- a/apps/web/src/pages/css/statCard.css
+++ b/apps/web/src/pages/css/statCard.css
@@ -297,3 +297,84 @@ input[type="number"] {
     grid-template-columns: 1fr;
   }
 }
+
+.stats-overview .watch-stat-cards,
+.statistics-dashboard .watch-stat-cards {
+  padding: 14px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(var(--primary-rgb), 0.045), rgba(var(--secondary-rgb), 0.025)),
+    rgba(15, 20, 29, 0.86);
+  box-shadow: none;
+}
+
+.stats-overview .watch-stat-cards .Heading,
+.statistics-dashboard .watch-stat-cards .Heading {
+  padding: 0 2px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.stats-overview .watch-stat-cards .Heading h1,
+.statistics-dashboard .watch-stat-cards .Heading h1 {
+  font-size: clamp(20px, 2vw, 28px);
+}
+
+.stats-overview .grid-stat-cards,
+.statistics-dashboard .grid-stat-cards {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  gap: 10px;
+  margin-top: 12px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.stats-overview .stat-card,
+.statistics-dashboard .stat-card {
+  min-height: 142px;
+  border-color: var(--surface-border-color) !important;
+  border-radius: 8px !important;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.045), rgba(var(--primary-rgb), 0.035)),
+    rgba(9, 13, 20, 0.92) !important;
+  box-shadow: none;
+}
+
+.stats-overview .stat-card:hover,
+.statistics-dashboard .stat-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(var(--primary-light-rgb), 0.28) !important;
+}
+
+.stats-overview .stat-card-overlay,
+.statistics-dashboard .stat-card-overlay {
+  grid-template-columns: 78px minmax(0, 1fr);
+  min-height: 142px;
+  padding: 9px;
+  border-radius: 8px;
+  background:
+    linear-gradient(90deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.66)),
+    rgba(7, 10, 16, 0.72) !important;
+}
+
+.stats-overview .stat-card-media,
+.statistics-dashboard .stat-card-media {
+  width: 78px;
+  height: 124px;
+  border-radius: 8px;
+}
+
+.stats-overview .stat-card-header span,
+.statistics-dashboard .stat-card-header span {
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.03em;
+}
+
+.stats-overview .stat-item-count,
+.statistics-dashboard .stat-item-count {
+  font-weight: 780;
+}

--- a/apps/web/src/pages/css/stats.css
+++ b/apps/web/src/pages/css/stats.css
@@ -230,6 +230,183 @@
   margin-bottom: 18px;
 }
 
+.stats-overview {
+  display: grid;
+  gap: 16px;
+}
+
+.stats-overview-kpis {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.stats-overview-kpis article,
+.stats-overview-panel,
+.stats-leader-card {
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(var(--primary-rgb), 0.08), rgba(255, 255, 255, 0.025)),
+    rgba(17, 22, 30, 0.82);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+}
+
+.stats-overview-kpis article {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 12px;
+  row-gap: 3px;
+  align-items: center;
+  min-width: 0;
+  padding: 15px;
+}
+
+.stats-overview-kpis svg {
+  grid-row: span 2;
+  width: 25px;
+  height: 25px;
+  color: var(--primary-light-color);
+}
+
+.stats-overview-kpis span,
+.stats-leader-card span,
+.stats-method-row span,
+.stats-method-row small {
+  min-width: 0;
+  color: #91a1b8;
+  font-size: 11px;
+  font-weight: 740;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stats-overview-kpis strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #f8fafc;
+  font-size: clamp(22px, 2.4vw, 32px);
+  font-weight: 780;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stats-overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.72fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.stats-overview-panel {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 16px;
+}
+
+.stats-leader-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.stats-leader-card {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr);
+  gap: 4px 12px;
+  align-items: center;
+  min-width: 0;
+  padding: 14px;
+}
+
+.stats-leader-card div {
+  grid-row: span 3;
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.24);
+  border-radius: 8px;
+  background: rgba(var(--primary-rgb), 0.13);
+  color: var(--primary-light-color);
+}
+
+.stats-leader-card svg {
+  width: 24px;
+  height: 24px;
+}
+
+.stats-leader-card img {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.stats-leader-card strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #f8fafc;
+  font-size: 18px;
+  font-weight: 780;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stats-leader-card small {
+  color: #aeb9c9;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.stats-method-list {
+  display: grid;
+  gap: 12px;
+}
+
+.stats-method-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) auto;
+  gap: 7px 10px;
+  align-items: center;
+}
+
+.stats-method-row strong {
+  color: #f8fafc;
+  font-size: 13px;
+  font-weight: 780;
+}
+
+.stats-method-row div {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.stats-method-row i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--primary-color), var(--secondary-color));
+}
+
+.stats-method-row small {
+  text-align: right;
+}
+
+.stats-overview-error,
+.stats-overview-empty {
+  padding: 14px;
+  border: 1px dashed rgba(var(--primary-light-rgb), 0.22);
+  border-radius: 8px;
+  color: #b8c5d8;
+  font-size: 13px;
+  font-weight: 650;
+}
+
 .stats-section-heading {
   display: flex;
   align-items: end;
@@ -363,6 +540,12 @@
   .stats-summary-strip {
     grid-template-columns: 1fr;
   }
+
+  .stats-overview-kpis,
+  .stats-overview-grid,
+  .stats-leader-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 620px) {
@@ -393,10 +576,43 @@
 }
 
 .watch-stats {
-  background: transparent;
+  display: grid;
+  gap: 14px;
+  max-width: 1840px;
+  margin: 0 auto;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent 240px),
+    transparent;
 }
 
-.stats-page-header,
+.stats-page-header {
+  position: sticky;
+  z-index: 4;
+  top: 0;
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) auto;
+  align-items: center;
+  margin-bottom: 0;
+  border-color: var(--surface-border-color);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(var(--primary-rgb), 0.12), rgba(var(--secondary-rgb), 0.045)),
+    rgba(14, 18, 26, 0.94);
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(18px);
+}
+
+.stats-workbench {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(var(--primary-rgb), 0.045), rgba(var(--secondary-rgb), 0.03)),
+    rgba(7, 10, 16, 0.72);
+}
+
 .stats-summary-strip div,
 .graph,
 .stats-tab-nav,
@@ -404,7 +620,7 @@
   border-color: var(--surface-border-color);
   border-radius: 8px;
   background: rgba(17, 22, 30, 0.82);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 .stats-title-icon {
@@ -481,4 +697,267 @@
 .stats-tooltip-title,
 .stats-tooltip-row {
   font-weight: 650;
+}
+
+.stats-controls {
+  display: grid;
+  grid-template-columns: 1fr;
+  justify-items: end;
+}
+
+.stats-tab-nav,
+.stats-range-panel {
+  width: fit-content;
+}
+
+.stats-summary-strip {
+  margin-bottom: 0;
+}
+
+.stats-summary-strip div {
+  min-height: 72px;
+}
+
+.stats-overview-kpis {
+  grid-template-columns: repeat(4, minmax(180px, 1fr));
+}
+
+.stats-overview-kpis article,
+.stats-overview-panel,
+.stats-leader-card,
+.stats-rank-panel {
+  border-color: var(--surface-border-color);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.045), rgba(var(--primary-rgb), 0.035)),
+    rgba(15, 20, 29, 0.9);
+  box-shadow: none;
+}
+
+.stats-overview-kpis article {
+  min-height: 94px;
+  border-left: 3px solid color-mix(in srgb, var(--primary-light-color) 70%, transparent);
+}
+
+.stats-overview-grid {
+  grid-template-columns: minmax(0, 1.36fr) minmax(340px, 0.64fr);
+}
+
+.stats-overview-panel-primary {
+  align-content: start;
+}
+
+.stats-overview-panel-primary .stats-section-heading {
+  align-items: flex-start;
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.stats-method-panel {
+  align-content: start;
+}
+
+.stats-method-panel .stats-section-heading {
+  display: block;
+  text-align: left;
+}
+
+.stats-rank-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.stats-rank-panel {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.stats-rank-panel header {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.stats-rank-panel header div {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.2);
+  border-radius: 8px;
+  background: rgba(var(--primary-rgb), 0.12);
+  color: var(--primary-light-color);
+}
+
+.stats-rank-panel header svg {
+  width: 18px;
+  height: 18px;
+}
+
+.stats-rank-panel header span {
+  color: #f8fafc;
+  font-size: 14px;
+  font-weight: 760;
+}
+
+.stats-rank-list {
+  display: grid;
+  gap: 6px;
+}
+
+.stats-rank-row {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+  padding: 8px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.055);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.028);
+  text-decoration: none;
+}
+
+a.stats-rank-row:hover {
+  border-color: rgba(var(--primary-light-rgb), 0.26);
+  background: rgba(var(--primary-rgb), 0.11);
+}
+
+.stats-rank-row small {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(var(--primary-rgb), 0.16);
+  color: var(--primary-light-color);
+  font-size: 11px;
+  font-weight: 780;
+}
+
+.stats-rank-row strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #f8fafc;
+  font-size: 13px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stats-rank-row span {
+  color: #dbeafe;
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.stats-rank-list p {
+  margin: 0;
+  padding: 12px;
+  color: #93a1b4;
+  font-size: 13px;
+  font-weight: 620;
+}
+
+.stats-chart-intro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid var(--surface-border-color);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(var(--secondary-rgb), 0.08), transparent 52%),
+    rgba(15, 20, 29, 0.86);
+}
+
+.stats-chart-intro p {
+  margin: 0 0 4px;
+  color: var(--primary-light-color);
+  font-size: 11px;
+  font-weight: 740;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stats-chart-intro h2 {
+  margin: 0;
+  color: #f8fafc;
+  font-size: clamp(26px, 2.6vw, 38px);
+  font-weight: 760;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.stats-chart-intro span {
+  display: block;
+  margin-top: 8px;
+  color: #9da8b8;
+  font-size: 13px;
+  font-weight: 560;
+}
+
+.stats-chart-intro strong {
+  flex: 0 0 auto;
+  padding: 8px 11px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.22);
+  border-radius: 8px;
+  background: rgba(var(--primary-rgb), 0.12);
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.graph {
+  height: 500px;
+  padding: 16px 16px 6px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent),
+    rgba(15, 20, 29, 0.9);
+}
+
+.statistics-graphs {
+  gap: 14px;
+  margin-bottom: 0;
+}
+
+.main-widget h1,
+.main-widget h2,
+.statistics-widget h1,
+.statistics-widget h2 {
+  font-size: 17px;
+}
+
+@media (max-width: 1120px) {
+  .stats-page-header,
+  .stats-overview-grid,
+  .stats-rank-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-controls,
+  .stats-tab-nav,
+  .stats-range-panel {
+    justify-self: stretch;
+    width: 100%;
+  }
+}
+
+@media (max-width: 760px) {
+  .watch-stats {
+    padding-inline: 12px;
+  }
+
+  .stats-overview-kpis {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-chart-intro {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }

--- a/apps/web/src/pages/css/users/users.css
+++ b/apps/web/src/pages/css/users/users.css
@@ -95,7 +95,7 @@
 }
 
 .users-primary-action,
-.users-page .btn-primary {
+.users-page .users-primary-action.btn-primary {
   display: inline-flex !important;
   gap: 8px;
   align-items: center;
@@ -159,8 +159,8 @@
 
 .users-management-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.32fr);
+  gap: 12px;
   align-items: start;
 }
 
@@ -168,6 +168,11 @@
   min-width: 0;
   border-radius: 18px;
   padding: 12px;
+}
+
+.users-access-panel {
+  position: sticky;
+  top: 14px;
 }
 
 .users-panel-header {
@@ -191,9 +196,37 @@
 
 .users-toolbar {
   display: grid;
-  grid-template-columns: minmax(260px, 1fr) minmax(140px, 0.3fr) minmax(140px, 0.3fr) minmax(126px, 0.24fr);
+  grid-template-columns: auto minmax(260px, 1fr) minmax(138px, 0.22fr) minmax(138px, 0.22fr) minmax(118px, 0.18fr) auto;
   gap: 10px;
-  min-width: min(860px, 100%);
+  min-width: min(1120px, 100%);
+}
+
+.users-view-toggle {
+  display: inline-grid;
+  grid-template-columns: repeat(2, minmax(74px, 1fr));
+  min-height: 42px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  background: rgba(5, 8, 13, 0.72);
+}
+
+.users-view-toggle button {
+  border: 0;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  background: transparent;
+  color: #cbd5e1;
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.users-view-toggle button:last-child {
+  border-right: 0;
+}
+
+.users-view-toggle button.is-active {
+  background: rgba(var(--primary-rgb), 0.24);
+  color: #fff;
 }
 
 .users-search {
@@ -243,9 +276,134 @@
   gap: 8px;
 }
 
+.users-profile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(292px, 1fr));
+  gap: 12px;
+}
+
+.users-profile-card {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background:
+    linear-gradient(145deg, rgba(var(--primary-rgb), 0.09), rgba(255, 255, 255, 0.026)),
+    rgba(8, 11, 17, 0.9);
+  box-shadow: 0 22px 58px rgba(0, 0, 0, 0.25);
+}
+
+.users-profile-card.is-account-card {
+  border-color: rgba(var(--primary-light-rgb), 0.16);
+  background:
+    linear-gradient(145deg, rgba(var(--primary-rgb), 0.13), rgba(var(--secondary-rgb), 0.035)),
+    rgba(8, 11, 17, 0.9);
+}
+
+.users-profile-card.is-hidden-user,
+.users-row-card.is-hidden-user {
+  border-style: dashed;
+  opacity: 0.72;
+}
+
+.users-profile-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.users-profile-actions {
+  display: inline-flex;
+  justify-content: flex-end;
+  min-width: 42px;
+}
+
+.users-profile-name {
+  min-width: 0;
+}
+
+.users-profile-name a,
+.users-profile-name strong {
+  display: block;
+  overflow: hidden;
+  color: #fff;
+  font-size: 22px;
+  font-weight: 950;
+  line-height: 1.16;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.users-profile-name span {
+  display: block;
+  margin-top: 7px;
+  color: #9aa7bb;
+  font-size: 12px;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.users-profile-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.source-hidden {
+  background: rgba(148, 163, 184, 0.18) !important;
+}
+
+.users-profile-metrics {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.users-profile-metrics span {
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.055);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.users-profile-metrics small,
+.users-profile-metrics strong {
+  display: block;
+  overflow: hidden;
+}
+
+.users-profile-metrics small {
+  color: #9aa7bb;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.users-profile-metrics strong {
+  margin-top: 6px;
+  color: #f8fafc;
+  font-size: 14px;
+  font-weight: 850;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.users-profile-role {
+  margin-top: auto;
+}
+
 .users-row-card {
   display: grid;
-  grid-template-columns: minmax(220px, 0.75fr) minmax(520px, 2fr) minmax(112px, auto) 156px minmax(42px, auto);
+  grid-template-columns: minmax(220px, 0.8fr) minmax(440px, 1.8fr) minmax(112px, auto) 150px minmax(42px, auto);
   gap: 10px;
   align-items: center;
   min-height: 76px;
@@ -401,14 +559,35 @@
 }
 
 .users-track-button {
-  width: 42px;
-  height: 36px;
-  min-height: 36px;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  min-height: 34px;
   padding: 0 !important;
-  border: 1px solid rgba(255, 255, 255, 0.1) !important;
-  border-radius: 12px !important;
-  background: rgba(148, 163, 184, 0.08) !important;
-  color: #f87171 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: #9aa7bb !important;
+  box-shadow: none !important;
+}
+
+.users-page .users-track-button.btn,
+.users-page .users-track-button.btn-primary,
+.users-page .users-track-button.btn:active {
+  border: 0 !important;
+  background: transparent !important;
+  color: #9aa7bb !important;
+  box-shadow: none !important;
+}
+
+.users-track-button:hover,
+.users-track-button:focus-visible,
+.users-page .users-track-button.btn:hover,
+.users-page .users-track-button.btn:focus-visible {
+  color: var(--primary-light-color) !important;
+  background: transparent !important;
 }
 
 .users-row-actions {
@@ -450,9 +629,15 @@
   background: rgba(248, 113, 113, 0.18) !important;
 }
 
-.users-row-card > .form-select {
-  width: 156px;
+.users-row-card > .form-select,
+.users-role-select {
+  width: 150px;
   min-height: 36px;
+}
+
+.users-profile-role .users-role-select,
+.users-profile-role .users-role-readonly {
+  width: 100%;
 }
 
 .users-role-readonly {
@@ -474,7 +659,41 @@
 }
 
 .users-track-button.is-tracked {
-  color: #34d399 !important;
+  color: var(--primary-light-color) !important;
+}
+
+.users-hidden-toggle {
+  display: inline-grid;
+  grid-template-columns: auto auto auto;
+  gap: 7px;
+  align-items: center;
+  min-height: 42px;
+  margin: 0;
+  padding: 0 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  background: rgba(5, 8, 13, 0.72);
+  color: #dbe6f7;
+  font-size: 13px;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.users-hidden-toggle .form-check {
+  min-height: 0;
+  margin: 0;
+}
+
+.users-hidden-toggle small {
+  display: inline-grid;
+  min-width: 22px;
+  height: 22px;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(var(--primary-rgb), 0.22);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 950;
 }
 
 .users-pagination {
@@ -507,6 +726,101 @@
 .users-modal .btn {
   border-color: rgba(var(--primary-light-rgb), 0.35) !important;
   color: #f8fafc !important;
+}
+
+.users-role-selector {
+  display: grid;
+  gap: 7px;
+  margin: 10px 0;
+  padding: 10px;
+  border: 1px solid rgba(var(--primary-light-rgb), 0.16);
+  border-radius: 14px;
+  background: rgba(5, 8, 13, 0.42);
+}
+
+.users-role-selector span {
+  color: #9aa7bb;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.users-permission-editor {
+  display: grid;
+  gap: 8px;
+}
+
+.users-permission-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  margin: 0;
+  padding: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: 13px;
+  background: rgba(5, 8, 13, 0.38);
+}
+
+.users-permission-row.is-enabled {
+  border-color: rgba(34, 197, 94, 0.22);
+  background:
+    linear-gradient(90deg, rgba(34, 197, 94, 0.09), transparent 66%),
+    rgba(5, 8, 13, 0.38);
+}
+
+.users-permission-row strong,
+.users-permission-row small {
+  display: block;
+}
+
+.users-permission-row strong {
+  color: #fff;
+  font-size: 13px;
+  font-weight: 950;
+}
+
+.users-permission-row small {
+  margin-top: 3px;
+  color: #95a3b7;
+  font-size: 11px;
+  font-weight: 720;
+  line-height: 1.35;
+}
+
+.users-permission-row .form-check {
+  min-height: 0;
+  margin: 0;
+}
+
+.users-permission-row .form-check-input,
+.users-page .form-check-input,
+.users-modal .form-check-input {
+  border-color: rgba(var(--primary-light-rgb), 0.35);
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.users-permission-row .form-check-input:checked,
+.users-page .form-check-input:checked,
+.users-modal .form-check-input:checked {
+  border-color: var(--primary-light-color);
+  background-color: var(--primary-color);
+}
+
+.users-permission-row .form-check-input:disabled {
+  opacity: 0.45;
+}
+
+.users-permission-note {
+  margin: 10px 0 0;
+  padding: 10px;
+  border: 1px dashed rgba(var(--primary-light-rgb), 0.22);
+  border-radius: 12px;
+  color: #aebbd0;
+  font-size: 11px;
+  font-weight: 780;
+  line-height: 1.45;
 }
 
 .local-users-panel {
@@ -793,6 +1107,10 @@
     grid-template-columns: 1fr;
   }
 
+  .users-access-panel {
+    position: static;
+  }
+
   .users-row-card {
     grid-template-columns: minmax(220px, 0.8fr) minmax(420px, 1.5fr) auto 160px minmax(42px, auto);
   }
@@ -821,6 +1139,7 @@
   .users-toolbar {
     min-width: 0;
     width: 100%;
+    grid-template-columns: repeat(2, minmax(180px, 1fr));
   }
 
   .users-row-card {
@@ -894,9 +1213,14 @@
   }
 
   .users-row-card > .form-select,
+  .users-role-select,
   .users-track-button,
   .users-row-actions {
     width: 100%;
+  }
+
+  .users-profile-grid {
+    grid-template-columns: 1fr;
   }
 
   .users-row-actions {

--- a/apps/web/src/pages/home.jsx
+++ b/apps/web/src/pages/home.jsx
@@ -19,6 +19,7 @@ import FilmLineIcon from "remixicon-react/FilmLineIcon";
 import GroupLineIcon from "remixicon-react/GroupLineIcon";
 import HeartPulseLineIcon from "remixicon-react/HeartPulseLineIcon";
 import MagicLineIcon from "remixicon-react/MagicLineIcon";
+import MedalFillIcon from "remixicon-react/MedalFillIcon";
 import Music2LineIcon from "remixicon-react/Music2LineIcon";
 import PlayCircleLineIcon from "remixicon-react/PlayCircleLineIcon";
 import RestartLineIcon from "remixicon-react/RestartLineIcon";
@@ -32,190 +33,41 @@ import User3LineIcon from "remixicon-react/User3LineIcon";
 import MenuLineIcon from "remixicon-react/MenuLineIcon";
 
 import Sessions from "./components/sessions/sessions";
+import { fetchActiveSessions } from "../lib/session-cache";
 import "./css/home.css";
+import {
+  DEFAULT_HOME_ORDER,
+  DEFAULT_HOME_SETTINGS,
+  HOME_PRESETS,
+  HOME_SECTION_DEFINITIONS,
+  HOME_WIDGET_SIZE_LABELS,
+  getHomeSettingsStorageKey,
+  loadHomeSettings,
+  normalizeHomeOrder,
+  normalizeHomeSettings,
+} from "../lib/home-settings";
 
 const numberFormat = new Intl.NumberFormat();
-const HOME_SETTINGS_STORAGE_PREFIX = "jellyglance_home_settings";
-const LEGACY_HOME_ORDER_STORAGE_KEY = "jellyglance_home_section_order";
-const HOME_LAYOUT_VERSION = 2;
-const HOME_SECTION_DEFINITIONS = [
-  { id: "sessions", label: "Active sessions" },
-  { id: "overview", label: "Overview" },
-  { id: "hall", label: "Hall of Fame" },
-  { id: "library", label: "Library health" },
-  { id: "catalog", label: "Catalog totals" },
-  { id: "milestones", label: "Milestones" },
-  { id: "week", label: "This week" },
-  { id: "attention", label: "Needs attention" },
-  { id: "trends", label: "Today vs last week" },
-  { id: "issues", label: "Library issues" },
-  { id: "watchParty", label: "Watch party" },
-  { id: "seasonGaps", label: "Season gaps" },
-  { id: "automation", label: "Automation feed" },
-  { id: "quickActions", label: "Quick actions" },
-  { id: "operations", label: "Operations" },
-];
-const DEFAULT_HOME_ORDER = HOME_SECTION_DEFINITIONS.map((section) => section.id);
-const CURATED_DEFAULT_HOME_ORDER = [
-  "sessions",
-  "attention",
-  "overview",
-  "operations",
-  "milestones",
-  "week",
-  "hall",
-  "trends",
-  "watchParty",
-  "quickActions",
-  "library",
-  "catalog",
-  "issues",
-  "seasonGaps",
-  "automation",
-];
-const DEFAULT_HOME_SETTINGS = {
-  order: CURATED_DEFAULT_HOME_ORDER,
-  hidden: ["seasonGaps"],
-  pinned: "",
-  density: "comfortable",
-  autoRotate: false,
-  preset: "default",
-  title: "",
-  theme: "default",
-  alertRules: { backupDays: 7, requestThreshold: 1, missingPosterThreshold: 1 },
-  dismissedAlerts: {},
-  sizes: {},
-  version: HOME_LAYOUT_VERSION,
-};
-const HOME_PRESETS = {
-  default: {
-    label: "Default",
-    order: CURATED_DEFAULT_HOME_ORDER,
-    hidden: ["seasonGaps"],
-    density: "comfortable",
-    sizes: {
-      sessions: "large",
-      overview: "large",
-      attention: "small",
-      quickActions: "small",
-    },
-  },
-  admin: {
-    label: "Admin",
-    order: ["attention", "operations", "quickActions", "automation", "sessions", "overview", "milestones", "trends", "issues", "week", "hall", "library", "catalog", "seasonGaps", "watchParty"],
-    hidden: ["watchParty"],
-    density: "compact",
-    sizes: {
-      attention: "small",
-      operations: "large",
-      quickActions: "small",
-      automation: "small",
-    },
-  },
-  family: {
-    label: "Family",
-    order: ["sessions", "watchParty", "week", "milestones", "hall", "overview", "trends", "catalog", "operations", "quickActions", "library", "attention", "issues", "seasonGaps", "automation"],
-    hidden: ["issues", "seasonGaps", "automation"],
-    density: "comfortable",
-    sizes: {
-      sessions: "large",
-      watchParty: "large",
-      week: "medium",
-      hall: "large",
-    },
-  },
-  media: {
-    label: "Media Stats",
-    order: ["overview", "milestones", "trends", "catalog", "library", "issues", "seasonGaps", "week", "watchParty", "hall", "sessions", "operations", "quickActions", "attention", "automation"],
-    hidden: ["automation"],
-    density: "comfortable",
-    sizes: {
-      overview: "large",
-      trends: "large",
-      catalog: "medium",
-      issues: "medium",
-    },
-  },
-  requests: {
-    label: "Requests First",
-    order: ["attention", "operations", "quickActions", "automation", "sessions", "week", "milestones", "overview", "hall", "trends", "library", "catalog", "issues", "seasonGaps", "watchParty"],
-    hidden: ["seasonGaps"],
-    density: "compact",
-    sizes: {
-      attention: "small",
-      operations: "large",
-      quickActions: "small",
-    },
-  },
-};
+const HOME_DASHBOARD_CACHE_KEY = "jellyglance_home_dashboard_cache";
+const HOME_OPERATIONS_CACHE_KEY = "jellyglance_home_operations_cache";
+const HOME_CACHE_MAX_AGE_MS = 5 * 60 * 1000;
 
-function normalizeHomeOrder(order) {
-  const knownSections = new Set(DEFAULT_HOME_ORDER);
-  const savedOrder = Array.isArray(order) ? order.filter((sectionId) => knownSections.has(sectionId)) : [];
-  const missingSections = DEFAULT_HOME_ORDER.filter((sectionId) => !savedOrder.includes(sectionId));
-  return [...savedOrder, ...missingSections];
-}
-
-function getHomeUserStorageKey() {
-  const payload = getHomeTokenPayload();
-  if (!payload) return `${HOME_SETTINGS_STORAGE_PREFIX}:browser`;
-  return `${HOME_SETTINGS_STORAGE_PREFIX}:${payload.sub || payload.userid || payload.username || payload.name || "user"}`;
-}
-
-function getHomeTokenPayload() {
-  const token = localStorage.getItem("token");
-  if (!token) return null;
+function loadHomeCache(key) {
   try {
-    return JSON.parse(window.atob(token.split(".")[1]?.replace(/-/g, "+").replace(/_/g, "/") || ""));
+    const cached = JSON.parse(localStorage.getItem(key) || "null");
+    if (!cached?.data || Date.now() - Number(cached.cachedAt || 0) > HOME_CACHE_MAX_AGE_MS) return null;
+    return cached.data;
   } catch {
     return null;
   }
 }
 
-function normalizeHomeSettings(settings) {
-  const normalized = { ...DEFAULT_HOME_SETTINGS, ...(settings || {}) };
-  const knownSections = new Set(DEFAULT_HOME_ORDER);
-  normalized.order = normalizeHomeOrder(normalized.order);
-  normalized.hidden = Array.isArray(normalized.hidden) ? [...new Set(normalized.hidden.filter((sectionId) => knownSections.has(sectionId)))] : [];
-  normalized.pinned = knownSections.has(normalized.pinned) ? normalized.pinned : "";
-  normalized.density = normalized.density === "compact" ? "compact" : "comfortable";
-  normalized.autoRotate = Boolean(normalized.autoRotate);
-  normalized.preset = normalized.preset || "custom";
-  normalized.title = typeof normalized.title === "string" ? normalized.title : "";
-  normalized.theme = ["default", "darker", "neon", "highContrast", "wall"].includes(normalized.theme) ? normalized.theme : "default";
-  normalized.alertRules = {
-    ...DEFAULT_HOME_SETTINGS.alertRules,
-    ...(normalized.alertRules || {}),
-  };
-  normalized.dismissedAlerts = normalized.dismissedAlerts && typeof normalized.dismissedAlerts === "object" ? normalized.dismissedAlerts : {};
-  normalized.sizes = normalized.sizes && typeof normalized.sizes === "object" ? { ...DEFAULT_HOME_SETTINGS.sizes, ...normalized.sizes } : DEFAULT_HOME_SETTINGS.sizes;
-  normalized.version = Number(normalized.version || 0);
-  return normalized;
-}
-
-function loadHomeSettings() {
-  const storageKey = getHomeUserStorageKey();
+function saveHomeCache(key, data) {
   try {
-    const saved = localStorage.getItem(storageKey);
-    if (saved) {
-      const parsed = JSON.parse(saved);
-      const normalized = normalizeHomeSettings(parsed);
-      const stillOldDefault = normalized.version < HOME_LAYOUT_VERSION && (!parsed.preset || parsed.preset === "custom") && JSON.stringify(normalizeHomeOrder(parsed.order)) === JSON.stringify(DEFAULT_HOME_ORDER);
-      return stillOldDefault ? normalizeHomeSettings(DEFAULT_HOME_SETTINGS) : normalized;
-    }
-
-    const legacyOrder = localStorage.getItem(LEGACY_HOME_ORDER_STORAGE_KEY);
-    if (legacyOrder) return normalizeHomeSettings({ order: JSON.parse(legacyOrder) });
+    localStorage.setItem(key, JSON.stringify({ cachedAt: Date.now(), data }));
   } catch {
-    return DEFAULT_HOME_SETTINGS;
+    // Ignore quota/private-mode failures; fresh network data still renders.
   }
-
-  const payload = getHomeTokenPayload();
-  const role = String(payload?.role || payload?.Role || payload?.roles?.[0] || "").toLowerCase();
-  if (role.includes("admin") || role.includes("owner") || role.includes("manager")) {
-    return normalizeHomeSettings({ ...DEFAULT_HOME_SETTINGS, ...HOME_PRESETS.admin, sizes: HOME_PRESETS.admin.sizes, preset: "admin" });
-  }
-  return normalizeHomeSettings({ ...DEFAULT_HOME_SETTINGS, ...HOME_PRESETS.family, sizes: HOME_PRESETS.family.sizes, preset: "family" });
 }
 
 function formatNumber(value) {
@@ -437,12 +289,122 @@ function HomeOpsCard({ icon: Icon, label, value, detail, to, accent = "cyan" }) 
   return <article className={`home-glass-card home-ops-card home-accent-${accent}`}>{content}</article>;
 }
 
+function getServiceByType(automationData, type) {
+  return (automationData?.services || []).find((service) => service.type === type);
+}
+
+function getTdarrWidget(bundle) {
+  const stats = bundle?.stats || {};
+  const firstJob = bundle?.active?.[0] || bundle?.queued?.[0];
+  const active = Number(stats.active || bundle?.active?.length || 0);
+  const queued = Number(stats.queue ?? stats.queued ?? bundle?.queued?.length ?? 0);
+
+  return {
+    status: active > 0 ? `${formatNumber(active)} active` : queued > 0 ? `${formatNumber(queued)} queued` : "Idle",
+    detail: firstJob?.title || firstJob?.name || firstJob?.file || "No active workers right now",
+    metrics: [
+      { label: "Active", value: formatNumber(active) },
+      { label: "Queue", value: formatNumber(queued) },
+      { label: "Saved", value: formatBytes(stats.saved || 0) },
+    ],
+  };
+}
+
+function getWizarrWidget(data) {
+  const invites = data?.invites || [];
+  const active = invites.filter((invite) => String(invite.status || "").toLowerCase() !== "used" && String(invite.status || "").toLowerCase() !== "expired").length;
+  const used = invites.filter((invite) => String(invite.status || "").toLowerCase() === "used").length;
+
+  return {
+    status: `${formatNumber(active)} active`,
+    detail: data?.servers?.length ? `${formatNumber(data.servers.length)} server${data.servers.length === 1 ? "" : "s"} connected` : "Invite manager ready",
+    metrics: [
+      { label: "Invites", value: formatNumber(data?.status?.invites ?? invites.length) },
+      { label: "Used", value: formatNumber(used) },
+      { label: "Users", value: formatNumber(data?.status?.users || 0) },
+    ],
+  };
+}
+
+function getAutomationServiceWidget(service, type) {
+  const isBazarr = type === "bazarr";
+  if (!service) {
+    return {
+      status: "Not connected",
+      detail: `Connect ${isBazarr ? "Bazarr" : "Prowlarr"} in Settings > Integrations.`,
+      metrics: [
+        { label: isBazarr ? "Missing" : "Indexers", value: "0" },
+        { label: isBazarr ? "Grabbed" : "Failed", value: "0" },
+        { label: "Issues", value: "0" },
+      ],
+    };
+  }
+
+  if (isBazarr) {
+    const missing = Number(service.stats?.missingEpisodes || 0) + Number(service.stats?.missingMovies || 0);
+    return {
+      status: service.ok ? "Healthy" : `${formatNumber(service.issues?.length || 0)} issue${service.issues?.length === 1 ? "" : "s"}`,
+      detail: service.version ? `Bazarr ${service.version}` : "Subtitle health",
+      metrics: [
+        { label: "Missing", value: formatNumber(missing) },
+        { label: "Grabbed", value: formatNumber(service.history?.length || 0) },
+        { label: "Issues", value: formatNumber(service.issues?.length || 0) },
+      ],
+    };
+  }
+
+  return {
+    status: service.ok ? "Healthy" : `${formatNumber(service.stats?.failedIndexers || 0)} failed`,
+    detail: service.version ? `Prowlarr ${service.version}` : "Indexer health",
+    metrics: [
+      { label: "Indexers", value: formatNumber(service.stats?.indexers || 0) },
+      { label: "Failed", value: formatNumber(service.stats?.failedIndexers || 0) },
+      { label: "Apps", value: formatNumber(service.stats?.applications || 0) },
+    ],
+  };
+}
+
+function HomeIntegrationWidget({ icon: Icon, title, eyebrow, widget, error, to }) {
+  return (
+    <>
+      <div className="home-integration-widget-head">
+        <span className="home-icon-bubble">
+          <Icon size={22} />
+        </span>
+        <div>
+          <p>{eyebrow}</p>
+          <h2>{title}</h2>
+        </div>
+        <Link to={to}>Open</Link>
+      </div>
+      {error ? (
+        <div className="home-integration-empty">{error}</div>
+      ) : (
+        <>
+          <strong className="home-integration-status">{widget ? widget.status : "Loading"}</strong>
+          <small className="home-integration-detail">{widget ? widget.detail : "Checking integration data"}</small>
+          <div className="home-integration-stat-grid">
+            {(widget?.metrics || Array.from({ length: 3 }, (_, index) => ({ label: ["One", "Two", "Three"][index], value: "" }))).map((metric) => (
+              <span key={metric.label}>
+                <b className={!widget ? "home-value-skeleton" : ""}>{metric.value}</b>
+                <em>{metric.label}</em>
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
 export default function Home({ kioskMode = false }) {
-  const [dashboard, setDashboard] = useState(null);
-  const [operations, setOperations] = useState({ requests: null, health: null });
+  const [dashboard, setDashboard] = useState(() => loadHomeCache(HOME_DASHBOARD_CACHE_KEY));
+  const [operations, setOperations] = useState(() => loadHomeCache(HOME_OPERATIONS_CACHE_KEY) || { requests: null, health: null });
+  const [integrationWidgets, setIntegrationWidgets] = useState({ tdarr: null, wizarr: null, automation: null });
+  const [integrationWidgetErrors, setIntegrationWidgetErrors] = useState({});
   const [isOrderingHome, setIsOrderingHome] = useState(false);
   const [isHomeActionsOpen, setIsHomeActionsOpen] = useState(false);
-  const [homeSettings, setHomeSettings] = useState(loadHomeSettings);
+  const [homeSettings, setHomeSettings] = useState(() => loadHomeSettings(kioskMode ? "kiosk" : "user"));
   const [rotateIndex, setRotateIndex] = useState(0);
   const [actionMessage, setActionMessage] = useState("");
   const [busyAction, setBusyAction] = useState("");
@@ -458,6 +420,7 @@ export default function Home({ kioskMode = false }) {
         headers: { Authorization: `Bearer ${config.token}` },
       });
       setDashboard(response.data);
+      saveHomeCache(HOME_DASHBOARD_CACHE_KEY, response.data);
       setError("");
     } catch (err) {
       console.log(err);
@@ -469,16 +432,17 @@ export default function Home({ kioskMode = false }) {
     const token = localStorage.getItem("token");
     if (!token) return;
 
-    const headers = { Authorization: `Bearer ${token}` };
-    const [requestsResponse, healthResponse] = await Promise.allSettled([
-      axios.get("/api/requests", { headers, params: forceRequests ? { force: "true" } : undefined }),
-      axios.get("/api/health", { headers }),
-    ]);
-
-    setOperations({
-      requests: requestsResponse.status === "fulfilled" ? requestsResponse.value.data : null,
-      health: healthResponse.status === "fulfilled" ? healthResponse.value.data : null,
-    });
+    try {
+      const response = await axios.get("/api/home/operations", {
+        headers: { Authorization: `Bearer ${token}` },
+        params: forceRequests ? { forceRequests: "true" } : undefined,
+      });
+      const nextOperations = response.data || { requests: null, health: null };
+      setOperations(nextOperations);
+      saveHomeCache(HOME_OPERATIONS_CACHE_KEY, nextOperations);
+    } catch (error) {
+      console.log(error);
+    }
   }
 
   useEffect(() => {
@@ -489,13 +453,13 @@ export default function Home({ kioskMode = false }) {
     }
 
     fetchDashboard();
-    const interval = setInterval(fetchDashboard, 60000 * 2);
+    const interval = setInterval(fetchDashboard, kioskMode ? 60000 * 5 : 60000 * 2);
 
     return () => {
       active = false;
       clearInterval(interval);
     };
-  }, []);
+  }, [kioskMode]);
 
   useEffect(() => {
     let active = true;
@@ -506,18 +470,29 @@ export default function Home({ kioskMode = false }) {
     }
 
     fetchOperations();
-    const interval = setInterval(fetchOperations, 60000);
+    const interval = setInterval(fetchOperations, kioskMode ? 60000 * 5 : 60000);
 
     return () => {
       active = false;
       clearInterval(interval);
     };
-  }, []);
+  }, [kioskMode]);
 
   const peakHours = dashboard?.peakHours || [];
   const maxPeak = useMemo(() => Math.max(...peakHours.map((hour) => Number(hour.count || 0)), 1), [peakHours]);
   const hallOfFame = dashboard?.hallOfFame || [];
   const podium = hallOfFame.slice(0, 3);
+  const podiumSlots = dashboard
+    ? [
+        { user: podium[1], rank: 2, medal: "Silver", avatarSize: 62 },
+        { user: podium[0], rank: 1, medal: "Gold", avatarSize: 78 },
+        { user: podium[2], rank: 3, medal: "Bronze", avatarSize: 58 },
+      ].filter((slot) => slot.user)
+    : [
+        { rank: 2, medal: "Silver", avatarSize: 62 },
+        { rank: 1, medal: "Gold", avatarSize: 78 },
+        { rank: 3, medal: "Bronze", avatarSize: 58 },
+      ];
   const runners = hallOfFame.slice(3, 5);
   const concentration = Number(dashboard?.libraryBalance?.concentration || 0);
   const requestStats = operations.requests?.stats || {};
@@ -550,10 +525,12 @@ export default function Home({ kioskMode = false }) {
   const seasonGaps = dashboard?.seasonGaps || [];
   const automationFeed = dashboard?.automationFeed || [];
   const milestones = useMemo(() => buildHomeMilestones(dashboard, operations), [dashboard, operations]);
+  const visibleWidgetCount = HOME_SECTION_DEFINITIONS.length - homeSettings.hidden.length;
+  const hiddenWidgetCount = homeSettings.hidden.length;
 
   useEffect(() => {
-    localStorage.setItem(getHomeUserStorageKey(), JSON.stringify(homeSettings));
-  }, [homeSettings]);
+    localStorage.setItem(getHomeSettingsStorageKey(kioskMode ? "kiosk" : "user"), JSON.stringify(homeSettings));
+  }, [homeSettings, kioskMode]);
 
   function updateHomeSettings(updater) {
     setHomeSettings((current) => normalizeHomeSettings(typeof updater === "function" ? updater(current) : { ...current, ...updater }));
@@ -675,12 +652,100 @@ export default function Home({ kioskMode = false }) {
 
     return ordered;
   }, [homeSettings.hidden, homeSettings.order, homeSettings.pinned, requestUrgency]);
-  const effectiveAutoRotate = homeSettings.autoRotate || kioskMode;
+  useEffect(() => {
+    if (!kioskMode) return undefined;
+    const refreshSessions = () => {
+      fetchActiveSessions().catch((error) => console.log(error));
+    };
+    refreshSessions();
+    const interval = setInterval(refreshSessions, 60000 * 5);
+    return () => clearInterval(interval);
+  }, [kioskMode]);
+
+  const effectiveAutoRotate = !kioskMode && homeSettings.autoRotate;
   const activeRotateSection = effectiveAutoRotate && orderedSectionIds.length ? orderedSectionIds[rotateIndex % orderedSectionIds.length] : null;
   const homeSectionOrder = useMemo(() => Object.fromEntries(orderedSectionIds.map((sectionId, index) => [sectionId, index])), [orderedSectionIds]);
   const getHomeSectionStyle = (sectionId) => ({ order: homeSectionOrder[sectionId] ?? DEFAULT_HOME_ORDER.indexOf(sectionId) });
-  const getHomeSectionClass = (sectionId, className = "") => `${className} home-widget-size-${homeSettings.sizes?.[sectionId] || "medium"}`.trim();
+  const getHomeSectionClass = (sectionId, className = "") => `${className} home-widget-size-${homeSettings.sizes?.[sectionId] || "medium"} ${isOrderingHome ? "is-home-widget-editing" : ""}`.trim();
   const shouldRenderSection = (sectionId) => orderedSectionIds.includes(sectionId) && (!activeRotateSection || activeRotateSection === sectionId);
+  const visibleIntegrationWidgets = useMemo(
+    () => ({
+      tdarr: orderedSectionIds.includes("tdarr"),
+      wizarr: orderedSectionIds.includes("wizarr"),
+      bazarr: orderedSectionIds.includes("bazarr"),
+      prowlarr: orderedSectionIds.includes("prowlarr"),
+    }),
+    [orderedSectionIds]
+  );
+
+  useEffect(() => {
+    const wantsTdarr = visibleIntegrationWidgets.tdarr;
+    const wantsWizarr = visibleIntegrationWidgets.wizarr;
+    const wantsAutomation = visibleIntegrationWidgets.bazarr || visibleIntegrationWidgets.prowlarr;
+    if (!wantsTdarr && !wantsWizarr && !wantsAutomation) return undefined;
+
+    let cancelled = false;
+
+    async function loadIntegrationWidgets() {
+      const requests = [];
+
+      if (wantsTdarr) {
+        requests.push(
+          axios.get("/api/tdarr/transcodes")
+            .then((response) => {
+              if (cancelled) return;
+              setIntegrationWidgets((current) => ({ ...current, tdarr: response.data }));
+              setIntegrationWidgetErrors((current) => ({ ...current, tdarr: "" }));
+            })
+            .catch((error) => {
+              if (cancelled) return;
+              setIntegrationWidgetErrors((current) => ({ ...current, tdarr: error.response?.data?.error || "Unable to load Tdarr." }));
+            })
+        );
+      }
+
+      if (wantsWizarr) {
+        requests.push(
+          axios.get("/api/wizarr/summary")
+            .then((response) => {
+              if (cancelled) return;
+              setIntegrationWidgets((current) => ({ ...current, wizarr: response.data }));
+              setIntegrationWidgetErrors((current) => ({ ...current, wizarr: "" }));
+            })
+            .catch((error) => {
+              if (cancelled) return;
+              setIntegrationWidgetErrors((current) => ({ ...current, wizarr: error.response?.data?.error || "Unable to load Wizarr." }));
+            })
+        );
+      }
+
+      if (wantsAutomation) {
+        requests.push(
+          axios.get("/api/automation-health")
+            .then((response) => {
+              if (cancelled) return;
+              setIntegrationWidgets((current) => ({ ...current, automation: response.data }));
+              setIntegrationWidgetErrors((current) => ({ ...current, bazarr: "", prowlarr: "" }));
+            })
+            .catch((error) => {
+              if (cancelled) return;
+              const message = error.response?.data?.error || "Unable to load automation health.";
+              setIntegrationWidgetErrors((current) => ({ ...current, bazarr: message, prowlarr: message }));
+            })
+        );
+      }
+
+      await Promise.all(requests);
+    }
+
+    loadIntegrationWidgets();
+    const interval = setInterval(loadIntegrationWidgets, kioskMode ? 60000 * 5 : 60000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [kioskMode, visibleIntegrationWidgets.tdarr, visibleIntegrationWidgets.wizarr, visibleIntegrationWidgets.bazarr, visibleIntegrationWidgets.prowlarr]);
 
   useEffect(() => {
     setRotateIndex(0);
@@ -742,7 +807,7 @@ export default function Home({ kioskMode = false }) {
             aria-pressed={isOrderingHome}
           >
             <Settings3LineIcon size={17} />
-            Order
+            Edit widgets
           </button>
         </div>
       </div>
@@ -751,8 +816,9 @@ export default function Home({ kioskMode = false }) {
         <div className="home-order-panel home-glass-card">
           <div className="home-order-panel-heading">
             <div>
-              <p>Homepage order</p>
-              <strong>Move, hide, pin, and preset sections.</strong>
+              <p>Widget editor</p>
+              <strong>Choose, reorder, resize, and save your Home layout.</strong>
+              <span>{visibleWidgetCount} visible · {hiddenWidgetCount} hidden · saved on this browser</span>
             </div>
             <button type="button" onClick={resetHomeOrder}>
               <RestartLineIcon size={16} />
@@ -830,6 +896,7 @@ export default function Home({ kioskMode = false }) {
               return (
               <article
                 key={sectionId}
+                className={`${isHidden ? "is-hidden-widget" : ""} ${draggedSection === sectionId ? "is-dragging-widget" : ""}`.trim()}
                 draggable
                 onDragStart={() => setDraggedSection(sectionId)}
                 onDragOver={(event) => event.preventDefault()}
@@ -837,14 +904,18 @@ export default function Home({ kioskMode = false }) {
                   moveSectionTo(draggedSection, sectionId);
                   setDraggedSection("");
                 }}
+                onDragEnd={() => setDraggedSection("")}
               >
                 <span>{index + 1}</span>
-                <strong className={isHidden ? "is-hidden-section" : ""}>{sectionLabels[sectionId]}</strong>
+                <strong className={isHidden ? "is-hidden-section" : ""}>
+                  {sectionLabels[sectionId]}
+                  <small>{isHidden ? "Hidden" : HOME_WIDGET_SIZE_LABELS[homeSettings.sizes?.[sectionId] || "medium"]}</small>
+                </strong>
                 <div>
                   <select title="Widget size" value={homeSettings.sizes?.[sectionId] || "medium"} onChange={(event) => updateWidgetSize(sectionId, event.target.value)}>
-                    <option value="small">S</option>
-                    <option value="medium">M</option>
-                    <option value="large">L</option>
+                    <option value="small">Compact</option>
+                    <option value="medium">Half</option>
+                    <option value="large">Full</option>
                   </select>
                   <button type="button" title={isHidden ? "Show section" : "Hide section"} onClick={() => toggleHomeSection(sectionId)}>
                     {isHidden ? <EyeOffLineIcon size={17} /> : <EyeLineIcon size={17} />}
@@ -865,7 +936,7 @@ export default function Home({ kioskMode = false }) {
 
       <div className="home-section-stack">
       {shouldRenderSection("sessions") ? <section className={getHomeSectionClass("sessions", "home-active-sessions home-glass-card")} style={getHomeSectionStyle("sessions")}>
-        <Sessions />
+        <Sessions surface={kioskMode ? "kiosk" : "home"} />
       </section> : null}
 
       {shouldRenderSection("overview") ? <section className={getHomeSectionClass("overview", "home-hero-grid")} aria-label="JellyGlance overview" style={getHomeSectionStyle("overview")}>
@@ -919,12 +990,20 @@ export default function Home({ kioskMode = false }) {
 
         <div className="home-hall-grid">
           <div className="home-podium">
-            {(dashboard ? podium : [0, 1, 2]).map((user, index) => (
-              <article key={dashboard ? user.userId || user.userName : `loading-${index}`} className={`home-podium-card rank-${index + 1}`}>
-                <span className="home-rank-medal">#{index + 1}</span>
-                {dashboard ? <HomeAvatar user={user} size={index === 0 ? 74 : 58} /> : <span className="home-avatar home-avatar-skeleton" style={{ width: index === 0 ? 74 : 58, height: index === 0 ? 74 : 58 }} />}
+            {podiumSlots.map(({ user, rank, medal, avatarSize }, index) => (
+              <article
+                key={dashboard ? user.userId || user.userName : `loading-${rank}`}
+                className={`home-podium-card rank-${rank}`}
+                style={dashboard && podium[0]?.plays ? { "--hall-share": `${Math.max(10, (Number(user.plays || 0) / Number(podium[0].plays || 1)) * 100)}%` } : undefined}
+              >
+                <span className="home-rank-medal">
+                  <span>{medal}</span>
+                  <MedalFillIcon size={18} aria-hidden="true" />
+                </span>
+                {dashboard ? <HomeAvatar user={user} size={avatarSize} /> : <span className="home-avatar home-avatar-skeleton" style={{ width: avatarSize, height: avatarSize }} />}
                 <strong className={!dashboard ? "home-name-skeleton" : ""}>{dashboard ? user.userName || "Unknown" : ""}</strong>
                 {dashboard ? <small>{formatNumber(user.plays)} plays</small> : <small className="home-detail-skeleton" />}
+                <span className="home-podium-share" aria-hidden="true" />
               </article>
             ))}
           </div>
@@ -1139,6 +1218,58 @@ export default function Home({ kioskMode = false }) {
               </article>
             )) : <span>No automation activity yet.</span>}
           </div>
+        </section>
+      ) : null}
+
+      {shouldRenderSection("tdarr") ? (
+        <section className={getHomeSectionClass("tdarr", "home-integration-widget home-glass-card")} aria-label="Tdarr transcode widget" style={getHomeSectionStyle("tdarr")}>
+          <HomeIntegrationWidget
+            icon={Tv2LineIcon}
+            title="Tdarr"
+            eyebrow="Active transcodes"
+            widget={integrationWidgets.tdarr ? getTdarrWidget(integrationWidgets.tdarr) : null}
+            error={integrationWidgetErrors.tdarr}
+            to="/active-transcodes"
+          />
+        </section>
+      ) : null}
+
+      {shouldRenderSection("wizarr") ? (
+        <section className={getHomeSectionClass("wizarr", "home-integration-widget home-glass-card")} aria-label="Wizarr invite widget" style={getHomeSectionStyle("wizarr")}>
+          <HomeIntegrationWidget
+            icon={GroupLineIcon}
+            title="Wizarr"
+            eyebrow="Invite manager"
+            widget={integrationWidgets.wizarr ? getWizarrWidget(integrationWidgets.wizarr) : null}
+            error={integrationWidgetErrors.wizarr}
+            to="/wizarr"
+          />
+        </section>
+      ) : null}
+
+      {shouldRenderSection("bazarr") ? (
+        <section className={getHomeSectionClass("bazarr", "home-integration-widget home-glass-card")} aria-label="Bazarr subtitle widget" style={getHomeSectionStyle("bazarr")}>
+          <HomeIntegrationWidget
+            icon={ChatCheckLineIcon}
+            title="Bazarr"
+            eyebrow="Subtitle health"
+            widget={integrationWidgets.automation ? getAutomationServiceWidget(getServiceByType(integrationWidgets.automation, "bazarr"), "bazarr") : null}
+            error={integrationWidgetErrors.bazarr}
+            to="/automation-health"
+          />
+        </section>
+      ) : null}
+
+      {shouldRenderSection("prowlarr") ? (
+        <section className={getHomeSectionClass("prowlarr", "home-integration-widget home-glass-card")} aria-label="Prowlarr indexer widget" style={getHomeSectionStyle("prowlarr")}>
+          <HomeIntegrationWidget
+            icon={BarChartGroupedLineIcon}
+            title="Prowlarr"
+            eyebrow="Indexer health"
+            widget={integrationWidgets.automation ? getAutomationServiceWidget(getServiceByType(integrationWidgets.automation, "prowlarr"), "prowlarr") : null}
+            error={integrationWidgetErrors.prowlarr}
+            to="/automation-health"
+          />
         </section>
       ) : null}
 

--- a/apps/web/src/pages/integrations.jsx
+++ b/apps/web/src/pages/integrations.jsx
@@ -18,11 +18,51 @@ import JellyfinIntegrationSettings from "./components/settings/JellyfinIntegrati
 import "./css/integrations.css";
 
 const iconUrl = (slug) => `https://cdn.jsdelivr.net/gh/selfhst/icons/svg/${slug}.svg`;
+const tdarrLogoUrl = "https://home.tdarr.io/static/media/logo3-min.246d6df44c7f16ddebaf.png";
+const integrationTabItems = [
+  ["media-server", "Media Server"],
+  ["automation", "Arr Apps"],
+  ["seerr", "Seerr Apps"],
+  ["downloads", "Download Clients"],
+  ["invites", "Invites / Transcodes"],
+];
+const integrationTabKeys = integrationTabItems.map(([key]) => key);
+
+function normalizeIntegrationTabSlug(value = "") {
+  const normalized = String(value || "")
+    .replace(/^#\/?/, "")
+    .trim()
+    .toLowerCase();
+  const aliases = {
+    media: "media-server",
+    mediaserver: "media-server",
+    "media-server": "media-server",
+    jellyfin: "media-server",
+    arr: "automation",
+    arrapps: "automation",
+    "arr-apps": "automation",
+    automation: "automation",
+    jellyseerr: "seerr",
+    overseerr: "seerr",
+    seerr: "seerr",
+    download: "downloads",
+    downloads: "downloads",
+    "download-clients": "downloads",
+    clients: "downloads",
+    invite: "invites",
+    invites: "invites",
+    "invites-transcodes": "invites",
+    transcodes: "invites",
+    tdarr: "invites",
+  };
+  return aliases[normalized] || (integrationTabKeys.includes(normalized) ? normalized : "");
+}
 
 const automationApps = [
   { name: "Sonarr", slug: "sonarr", purpose: "Series automation", accent: "#35c5f4" },
   { name: "Radarr", slug: "radarr", purpose: "Movie automation", accent: "#f4c430" },
   { name: "Lidarr", slug: "lidarr", purpose: "Music automation", accent: "var(--secondary-color)" },
+  { name: "Prowlarr", slug: "prowlarr", purpose: "Indexer management", accent: "#4aa8f0" },
   { name: "Bazarr", slug: "bazarr", purpose: "Subtitle automation", accent: "#84d160" },
   { name: "Jellyseerr", slug: "jellyseerr", purpose: "Request management", accent: "#6366f1" },
   { name: "Overseerr", slug: "overseerr", purpose: "Request management", accent: "#7dd3fc" },
@@ -38,7 +78,10 @@ const downloadClientOptions = [
   { name: "rTorrent", slug: null, protocol: "Torrent" },
 ];
 
-const thirdPartyOptions = [{ name: "Wizarr", slug: "wizarr", purpose: "Jellyfin invite links", accent: "#8b5cf6" }];
+const thirdPartyOptions = [
+  { name: "Tdarr", slug: "tdarr", purpose: "Active transcodes", accent: "var(--primary-light-color)", secretOptional: true },
+  { name: "Wizarr", slug: "wizarr", purpose: "Jellyfin invite links", accent: "#8b5cf6" },
+];
 
 const initialThirdPartyApps = thirdPartyOptions.map((app, index) => ({
   ...app,
@@ -81,11 +124,21 @@ function normalizeThirdPartyApps(savedApps) {
 }
 
 function AppIcon({ app }) {
-  if (!app.slug) {
+  const normalizedName = String(app.name || "").toLowerCase();
+  if (normalizedName.includes("tdarr")) {
+    return <img src={tdarrLogoUrl} alt="" loading="lazy" decoding="async" />;
+  }
+
+  const iconSlug =
+    normalizedName.includes("home assistant") || normalizedName.includes("hacs")
+      ? "home-assistant"
+      : app.slug;
+
+  if (!iconSlug) {
     return <span className="integration-fallback-icon">{app.name.slice(0, 2)}</span>;
   }
 
-  return <img src={iconUrl(app.slug)} alt="" loading="lazy" decoding="async" />;
+  return <img src={iconUrl(iconSlug)} alt="" loading="lazy" decoding="async" />;
 }
 
 function formatHealthDate(value) {
@@ -130,10 +183,11 @@ function buildHealthTimeline(entries = []) {
 function IntegrationCard({ app, type, onChange, onRemove, onSave, onTest, onCopySecret, removable = false }) {
   const usesUserPass = type === "download" && app.auth === "userpass";
   const usesPasswordOnly = type === "download" && app.auth === "password";
-  const authLabel = usesUserPass || usesPasswordOnly ? "Password" : "API key";
+  const secretOptional = Boolean(app.secretOptional) || String(app.name || app.slug || "").toLowerCase().includes("tdarr");
+  const authLabel = usesUserPass || usesPasswordOnly ? "Password" : secretOptional ? "API key (optional)" : "API key";
   const connected = Boolean(app.connected);
   const values = app.values || {};
-  const secretPlaceholder = usesPasswordOnly || usesUserPass ? `${app.name} password` : "Paste API key";
+  const secretPlaceholder = usesPasswordOnly || usesUserPass ? `${app.name} password` : secretOptional ? "Paste API key if auth is enabled" : "Paste API key";
   const [showSecret, setShowSecret] = useState(false);
 
   return (
@@ -209,9 +263,10 @@ function IntegrationCard({ app, type, onChange, onRemove, onSave, onTest, onCopy
   );
 }
 
-export default function Integrations({ embedded = false, firstRun = false }) {
+export default function Integrations({ embedded = false, firstRun = false, activeTab: controlledActiveTab = "", onTabChange }) {
   const fileInputRef = useRef(null);
-  const [activeTab, setActiveTab] = useState("media-server");
+  const [internalActiveTab, setInternalActiveTab] = useState(normalizeIntegrationTabSlug(controlledActiveTab) || "media-server");
+  const activeTab = normalizeIntegrationTabSlug(controlledActiveTab) || internalActiveTab;
   const [arrApps, setArrApps] = useState(initialAutomationApps);
   const [clients, setClients] = useState([]);
   const [thirdParty, setThirdParty] = useState(initialThirdPartyApps);
@@ -235,6 +290,19 @@ export default function Integrations({ embedded = false, firstRun = false }) {
     });
     return lookup;
   }, [healthHistory]);
+
+  useEffect(() => {
+    const normalized = normalizeIntegrationTabSlug(controlledActiveTab);
+    if (normalized) {
+      setInternalActiveTab(normalized);
+    }
+  }, [controlledActiveTab]);
+
+  function selectIntegrationTab(tabKey) {
+    const normalized = normalizeIntegrationTabSlug(tabKey) || "media-server";
+    setInternalActiveTab(normalized);
+    onTabChange?.(normalized);
+  }
 
   useEffect(() => {
     async function loadIntegrations() {
@@ -442,7 +510,8 @@ export default function Integrations({ embedded = false, firstRun = false }) {
     const needsUsername = listName === "clients" && selectedIntegration.auth === "userpass";
     const missingUrl = !values.url?.trim();
     const missingUsername = needsUsername && !values.username?.trim();
-    const missingSecret = !values.secret?.trim();
+    const secretOptional = listName === "thirdParty" && (selectedIntegration.secretOptional || String(selectedIntegration.name || selectedIntegration.slug || "").toLowerCase().includes("tdarr"));
+    const missingSecret = !secretOptional && !values.secret?.trim();
     const invalidUrl = values.url?.trim() && !/^https?:\/\//i.test(values.url.trim());
     const validationError = invalidUrl ? "URL must start with http:// or https://" : "Fill in all required fields before testing";
 
@@ -554,14 +623,8 @@ export default function Integrations({ embedded = false, firstRun = false }) {
       </section>
 
       <nav className="integration-subtabs" aria-label="Integration categories">
-        {[
-          ["media-server", "Media Server"],
-          ["automation", "Arr Apps"],
-          ["seerr", "Seerr Apps"],
-          ["downloads", "Download Clients"],
-          ["invites", "Invites"],
-        ].map(([key, label]) => (
-          <button type="button" className={activeTab === key ? "is-active" : ""} onClick={() => setActiveTab(key)} key={key}>
+        {integrationTabItems.map(([key, label]) => (
+          <button type="button" className={activeTab === key ? "is-active" : ""} onClick={() => selectIntegrationTab(key)} key={key}>
             {label}
           </button>
         ))}
@@ -576,7 +639,7 @@ export default function Integrations({ embedded = false, firstRun = false }) {
           <div className="integration-section-title">
             <div>
               <h2>Arr Apps</h2>
-              <span>Sonarr, Radarr, Lidarr, and Bazarr</span>
+              <span>Sonarr, Radarr, Lidarr, Prowlarr, and Bazarr</span>
             </div>
             <Settings3LineIcon />
           </div>
@@ -616,6 +679,15 @@ export default function Integrations({ embedded = false, firstRun = false }) {
                 onCopySecret={copySecret}
               />
             ))}
+          </div>
+          <div className="integration-link-panel">
+            <div>
+              <strong>Automation health</strong>
+              <span>Review Bazarr subtitles and Prowlarr indexer status from one JellyGlance view.</span>
+            </div>
+            <div className="integration-link-actions">
+              <Link to="/automation-health">Open Automation Health</Link>
+            </div>
           </div>
         </section>
       ) : null}
@@ -731,8 +803,8 @@ export default function Integrations({ embedded = false, firstRun = false }) {
         <section className="integration-section">
           <div className="integration-section-title">
             <div>
-              <h2>Invite Managers</h2>
-              <span>Wizarr user invites for Jellyfin and other media servers</span>
+              <h2>Third-party Apps</h2>
+              <span>Wizarr invites and Tdarr active transcode monitoring</span>
             </div>
             <UserAddLineIcon />
           </div>
@@ -775,10 +847,13 @@ export default function Integrations({ embedded = false, firstRun = false }) {
           </div>
           <div className="integration-link-panel">
             <div>
-              <strong>Manage invite links</strong>
-              <span>Create, copy, and revoke Wizarr invitations from JellyGlance once the connection tests successfully.</span>
+              <strong>Open connected tools</strong>
+              <span>Manage Wizarr invitations or monitor Tdarr active, queued, and finished transcodes from JellyGlance.</span>
             </div>
-            <Link to="/wizarr">Open Wizarr links</Link>
+            <div className="integration-link-actions">
+              <Link to="/wizarr">Open Wizarr links</Link>
+              <Link to="/active-transcodes">Open Active Transcodes</Link>
+            </div>
           </div>
         </section>
       ) : null}

--- a/apps/web/src/pages/requests.jsx
+++ b/apps/web/src/pages/requests.jsx
@@ -5,6 +5,8 @@ import CloseCircleLineIcon from "remixicon-react/CloseCircleLineIcon";
 import ErrorWarningLineIcon from "remixicon-react/ErrorWarningLineIcon";
 import ExternalLinkLineIcon from "remixicon-react/ExternalLinkLineIcon";
 import Edit2LineIcon from "remixicon-react/Edit2LineIcon";
+import FileList3LineIcon from "remixicon-react/FileList3LineIcon";
+import GridLineIcon from "remixicon-react/GridLineIcon";
 import AccountCircleFillIcon from "remixicon-react/AccountCircleFillIcon";
 import RefreshLineIcon from "remixicon-react/RefreshLineIcon";
 import SearchLineIcon from "remixicon-react/SearchLineIcon";
@@ -58,6 +60,109 @@ function getRequesterName(request) {
   return request?.requester?.name || request?.requestedBy || "Unknown user";
 }
 
+function normalizeOwnerValue(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function getCurrentRequestOwnerCandidates(config = {}) {
+  const auth = config.settings?.auth || {};
+  const jellyfinUser = auth.jellyfinUser || {};
+  return [
+    config.username,
+    auth.username,
+    auth.email,
+    jellyfinUser.id,
+    jellyfinUser.Id,
+    jellyfinUser.name,
+    jellyfinUser.Name,
+    jellyfinUser.username,
+    jellyfinUser.UserName,
+  ]
+    .map(normalizeOwnerValue)
+    .filter(Boolean);
+}
+
+function isOwnRequest(request, ownerCandidates = []) {
+  if (!ownerCandidates.length) return false;
+  const requester = request?.requester || {};
+  return [
+    request?.requestedBy,
+    requester.id,
+    requester.userId,
+    requester.jellyfinUserId,
+    requester.name,
+    requester.username,
+    requester.email,
+  ]
+    .map(normalizeOwnerValue)
+    .filter(Boolean)
+    .some((candidate) => ownerCandidates.includes(candidate));
+}
+
+function getInitials(value) {
+  return String(value || "?")
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("") || "?";
+}
+
+function RequestFilterOptionAvatar({ option }) {
+  if (!option?.avatarUrl && !option?.initials) return null;
+
+  return (
+    <span className="requests-filter-option-avatar">
+      {option.avatarUrl ? (
+        <img src={option.avatarUrl} alt="" loading="lazy" decoding="async" onError={(event) => { event.currentTarget.style.display = "none"; }} />
+      ) : null}
+      <span>{option.initials}</span>
+    </span>
+  );
+}
+
+function RequestFilterDropdown({ label, value, options, onChange }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedOption = options.find((option) => option.value === value) || options[0];
+
+  return (
+    <div
+      className={`requests-filter-dropdown${isOpen ? " is-open" : ""}`}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setIsOpen(false);
+        }
+      }}
+    >
+      <span>{label}</span>
+      <button type="button" aria-haspopup="listbox" aria-expanded={isOpen} onClick={() => setIsOpen((open) => !open)}>
+        <RequestFilterOptionAvatar option={selectedOption} />
+        <strong>{selectedOption?.label || "Select"}</strong>
+      </button>
+      {isOpen ? (
+        <div className="requests-filter-dropdown-menu" role="listbox" tabIndex={-1}>
+          {options.map((option) => (
+            <button
+              type="button"
+              key={option.value}
+              className={option.value === value ? "is-selected" : ""}
+              role="option"
+              aria-selected={option.value === value}
+              onClick={() => {
+                onChange(option.value);
+                setIsOpen(false);
+              }}
+            >
+              <RequestFilterOptionAvatar option={option} />
+              <span>{option.label}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function getRequesterAvatarUrl(request) {
   const requester = request?.requester || {};
   if (requester.jellyfinUserId) {
@@ -80,7 +185,7 @@ function RequesterIdentity({ request, compact = false }) {
     <span className={`requests-user-chip${compact ? " is-compact" : ""}`}>
       <span className="requests-user-avatar">
         {avatarUrl ? (
-          <img src={avatarUrl} alt="" onError={(event) => { event.currentTarget.style.display = "none"; }} />
+          <img src={avatarUrl} alt="" loading="lazy" decoding="async" onError={(event) => { event.currentTarget.style.display = "none"; }} />
         ) : (
           <span>{initials}</span>
         )}
@@ -108,7 +213,7 @@ function RequesterByline({ request }) {
     <span className="requests-requester-byline">
       <span className="requests-requester-avatar">
         {avatarUrl ? (
-          <img src={avatarUrl} alt="" onError={(event) => { event.currentTarget.style.display = "none"; }} />
+          <img src={avatarUrl} alt="" loading="lazy" decoding="async" onError={(event) => { event.currentTarget.style.display = "none"; }} />
         ) : (
           <span>{initials}</span>
         )}
@@ -129,6 +234,7 @@ function RequestPoster({ request, large = false }) {
         src={posterUrl}
         alt=""
         loading={large ? undefined : "lazy"}
+        decoding="async"
         onError={() => {
           if (posterIndex < urls.length - 1) {
             setPosterIndex((current) => current + 1);
@@ -157,22 +263,28 @@ export default function Requests() {
   const [requestOptionForms, setRequestOptionForms] = useState({});
   const [requestOptionsLoading, setRequestOptionsLoading] = useState({});
   const [statusFilter, setStatusFilter] = useState("All");
+  const [requesterFilter, setRequesterFilter] = useState("all");
   const [sortMode, setSortMode] = useState("newest");
+  const [queueView, setQueueView] = useState("cards");
   const [selectedRequest, setSelectedRequest] = useState(null);
   const [selectedRequestLoading, setSelectedRequestLoading] = useState(false);
   const [editingRequestId, setEditingRequestId] = useState("");
-  const currentRole = useMemo(() => {
+  const currentConfig = useMemo(() => {
     try {
-      return JSON.parse(localStorage.getItem("config") || "{}")?.settings?.auth?.role || "Viewer";
+      return JSON.parse(localStorage.getItem("config") || "{}");
     } catch {
-      return "Viewer";
+      return {};
     }
   }, []);
+  const currentRole = currentConfig?.settings?.auth?.role || "Viewer";
   const canManageRequests = currentRole === "Owner" || currentRole === "Admin";
+  const currentOwnerCandidates = useMemo(() => getCurrentRequestOwnerCandidates(currentConfig), [currentConfig]);
 
   const visibleRequests = useMemo(() => {
     const normalizedSearch = mediaSearch.trim().toLowerCase();
     const filtered = (data.requests || []).filter((request) => {
+      if (!canManageRequests && !isOwnRequest(request, currentOwnerCandidates)) return false;
+      if (canManageRequests && requesterFilter !== "all" && getRequesterName(request) !== requesterFilter) return false;
       const statusMatches = statusFilter === "All" || String(request.status).toLowerCase() === statusFilter.toLowerCase();
       if (!statusMatches) return false;
       if (!normalizedSearch) return true;
@@ -193,9 +305,40 @@ export default function Requests() {
       return new Date(second.createdAt || 0).getTime() - new Date(first.createdAt || 0).getTime();
     });
     return sorted;
-  }, [data.requests, mediaSearch, sortMode, statusFilter]);
+  }, [canManageRequests, currentOwnerCandidates, data.requests, mediaSearch, requesterFilter, sortMode, statusFilter]);
 
   const statuses = useMemo(() => ["All", ...new Set((data.requests || []).map((request) => request.status).filter(Boolean))], [data.requests]);
+  const sortOptions = useMemo(
+    () => [
+      { value: "newest", label: "Newest first" },
+      { value: "oldest", label: "Oldest first" },
+      { value: "requester", label: "Requester" },
+      { value: "status", label: "Status" },
+      { value: "availability", label: "Availability" },
+    ],
+    []
+  );
+  const requesterOptions = useMemo(
+    () => {
+      const requesters = new Map();
+      (data.requests || []).forEach((request) => {
+        const name = getRequesterName(request);
+        if (!name || requesters.has(name)) return;
+        requesters.set(name, {
+          value: name,
+          label: name,
+          avatarUrl: getRequesterAvatarUrl(request),
+          initials: getInitials(name),
+        });
+      });
+
+      return [
+        { value: "all", label: "All users" },
+        ...[...requesters.values()].sort((a, b) => a.label.localeCompare(b.label)),
+      ];
+    },
+    [data.requests]
+  );
   const seerrSources = data.sources || [];
 
   function getDefaultOptionForm(options) {
@@ -587,40 +730,21 @@ export default function Requests() {
 
   return (
     <div className="requests-page">
-      <header className="requests-hero">
-        <div>
-          <p>Request center</p>
-          <h1>Requests</h1>
-          <span>Search Seerr, choose destinations, and manage the request queue from one place.</span>
-        </div>
-        <div className="requests-hero-stats" aria-label="Request status overview">
-          <span>
-            <strong>{data.stats?.badgeCount || 0}</strong>
-            Needs action
-          </span>
-          <span>
-            <strong>{data.stats?.available || 0}</strong>
-            Available
-          </span>
-          <span>
-            <strong>{seerrSources.length}</strong>
-            Sources
-          </span>
-        </div>
-        <button type="button" onClick={() => loadRequests(true)} disabled={loading}>
-          <RefreshLineIcon size={18} />
-          {loading ? "Refreshing" : "Refresh"}
-        </button>
-      </header>
-
       {actionMessage ? <div className="requests-action-message">{actionMessage}</div> : null}
 
       <section className="requests-discovery">
         <div className="requests-discovery-head">
           <div>
-            <p>Search</p>
             <h2>Find or request media</h2>
             <span>Search once to filter existing requests and request new media from Seerr results.</span>
+          </div>
+          <div className="requests-view-toggle" role="group" aria-label="Request queue view">
+            <button type="button" className={queueView === "cards" ? "is-active" : ""} aria-pressed={queueView === "cards"} onClick={() => setQueueView("cards")} title="Card view" aria-label="Card view">
+              <GridLineIcon size={18} />
+            </button>
+            <button type="button" className={queueView === "list" ? "is-active" : ""} aria-pressed={queueView === "list"} onClick={() => setQueueView("list")} title="List view" aria-label="List view">
+              <FileList3LineIcon size={18} />
+            </button>
           </div>
         </div>
         <label className="requests-media-search">
@@ -635,17 +759,11 @@ export default function Requests() {
             {mediaSearchLoading ? "Searching" : "Search"}
           </button>
         </label>
-        <section className="requests-control-bar">
-          <label>
-            <span>Sort queue</span>
-            <select value={sortMode} onChange={(event) => setSortMode(event.target.value)}>
-              <option value="newest">Newest first</option>
-              <option value="oldest">Oldest first</option>
-              <option value="requester">Requester</option>
-              <option value="status">Status</option>
-              <option value="availability">Availability</option>
-            </select>
-          </label>
+        <section className={`requests-control-bar${canManageRequests ? " has-user-filter" : ""}`}>
+          <RequestFilterDropdown label="Sort queue" value={sortMode} options={sortOptions} onChange={setSortMode} />
+          {canManageRequests ? (
+            <RequestFilterDropdown label="User" value={requesterFilter} options={requesterOptions} onChange={setRequesterFilter} />
+          ) : null}
           <strong>{visibleRequests.length} shown from {data.requests?.length || 0}</strong>
         </section>
         <nav className="requests-filter-strip" aria-label="Request status filters">
@@ -715,7 +833,7 @@ export default function Requests() {
         ) : null}
       </section>
 
-      <section className="requests-board">
+      <section className={`requests-board is-${queueView}`}>
         {visibleRequests.map((request) => {
           const age = getRequestAge(request.createdAt);
           return (

--- a/apps/web/src/pages/settings.jsx
+++ b/apps/web/src/pages/settings.jsx
@@ -1,28 +1,11 @@
 import { Tabs, Tab } from "react-bootstrap";
-import { useEffect, useState } from "react";
-
-import SettingsConfig from "./components/settings/settingsConfig";
-import Tasks from "./components/settings/Tasks";
-import SecuritySettings from "./components/settings/security";
-import ApiKeys from "./components/settings/apiKeys";
-import LibrarySelector from "./library_selector";
-import ActivityMonitorSettings from "./components/settings/ActivityMonitorSettings";
-import WebhooksSettings from "./components/settings/webhooks";
-import Integrations from "./integrations";
-import RepairHub from "./repair-hub";
-import HealthSettings from "./components/settings/health";
-import JellystatImport from "./components/settings/JellystatImport";
-import TautulliImport from "./components/settings/TautulliImport";
-import NewsletterSettings from "./components/settings/NewsletterSettings";
-import NotificationSettings from "./components/settings/NotificationSettings";
-import JellyfinAdminSettings from "./components/settings/JellyfinAdminSettings";
-
-import Logs from "./components/settings/logs";
+import { lazy, Suspense, useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import "./css/settings/settings.css";
 import { Trans } from "react-i18next";
-import BackupPage from "./components/settings/backup_page";
 import ErrorBoundary from "./components/general/ErrorBoundary";
+import Loading from "./components/general/loading";
 import Settings3LineIcon from "remixicon-react/Settings3LineIcon";
 import ShieldKeyholeLineIcon from "remixicon-react/ShieldKeyholeLineIcon";
 import PulseLineIcon from "remixicon-react/PulseLineIcon";
@@ -39,6 +22,26 @@ import MailSettingsLineIcon from "remixicon-react/MailSettingsLineIcon";
 import ToolsLineIcon from "remixicon-react/ToolsLineIcon";
 import DeviceLineIcon from "remixicon-react/DeviceLineIcon";
 import AppsLineIcon from "remixicon-react/AppsLineIcon";
+import Tv2LineIcon from "remixicon-react/Tv2LineIcon";
+
+const SettingsConfig = lazy(() => import("./components/settings/settingsConfig"));
+const Tasks = lazy(() => import("./components/settings/Tasks"));
+const SecuritySettings = lazy(() => import("./components/settings/security"));
+const ApiKeys = lazy(() => import("./components/settings/apiKeys"));
+const LibrarySelector = lazy(() => import("./library_selector"));
+const ActivityMonitorSettings = lazy(() => import("./components/settings/ActivityMonitorSettings"));
+const WebhooksSettings = lazy(() => import("./components/settings/webhooks"));
+const Integrations = lazy(() => import("./integrations"));
+const RepairHub = lazy(() => import("./repair-hub"));
+const HealthSettings = lazy(() => import("./components/settings/health"));
+const JellystatImport = lazy(() => import("./components/settings/JellystatImport"));
+const TautulliImport = lazy(() => import("./components/settings/TautulliImport"));
+const NewsletterSettings = lazy(() => import("./components/settings/NewsletterSettings"));
+const NotificationSettings = lazy(() => import("./components/settings/NotificationSettings"));
+const JellyfinAdminSettings = lazy(() => import("./components/settings/JellyfinAdminSettings"));
+const BackupPage = lazy(() => import("./components/settings/backup_page"));
+const Logs = lazy(() => import("./components/settings/logs"));
+const KioskSettings = lazy(() => import("./components/settings/KioskSettings"));
 
 function tabTitle(Icon, label) {
   return (
@@ -50,30 +53,50 @@ function tabTitle(Icon, label) {
 }
 
 function SettingsPane({ children }) {
-  return <ErrorBoundary>{children}</ErrorBoundary>;
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={<Loading />}>{children}</Suspense>
+    </ErrorBoundary>
+  );
 }
 
 const settingsTabItems = [
-  { key: "tabGeneral", Icon: Settings3LineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.SETTINGS"} /> },
-  { key: "tabSecurity", Icon: ShieldKeyholeLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.SECURITY"} /> },
-  { key: "tabActivityMonitor", Icon: PulseLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.ACTIVITY_MONITOR"} defaults="Activity Monitor" /> },
-  { key: "tabJellyfinDevices", Icon: DeviceLineIcon, label: "Authorised Devices" },
-  { key: "tabJellyfinPlugins", Icon: AppsLineIcon, label: "Plugins" },
-  { key: "tabTasks", Icon: TaskLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.TASKS"} /> },
-  { key: "tabLibraries", Icon: GalleryLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.LIBRARY_SETTINGS"} /> },
-  { key: "tabIntegrations", Icon: Plug2LineIcon, label: "Integrations" },
-  { key: "tabKeys", Icon: Key2LineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.API_KEY"} /> },
-  { key: "tabWebhooks", Icon: Notification3LineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.WEBHOOKS"} /> },
-  { key: "tabNotifications", Icon: Notification3LineIcon, label: "Notifications" },
-  { key: "tabBackup", Icon: ArchiveLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.BACKUP"} /> },
-  { key: "tabImports", Icon: Database2LineIcon, label: "Imports" },
-  { key: "tabNewsletter", Icon: MailSettingsLineIcon, label: "Newsletter" },
-  { key: "tabHealth", Icon: HeartPulseLineIcon, label: "Health" },
-  { key: "tabRepair", Icon: ToolsLineIcon, label: "Repair" },
-  { key: "tabLogs", Icon: FileList3LineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.LOGS"} /> },
+  { key: "tabGeneral", Icon: Settings3LineIcon, label: "General", group: "Core" },
+  { key: "tabSecurity", Icon: ShieldKeyholeLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.SECURITY"} />, group: "Core" },
+  { key: "tabKiosk", Icon: Tv2LineIcon, label: "Kiosk", group: "Core" },
+  { key: "tabLibraries", Icon: GalleryLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.LIBRARY_SETTINGS"} />, group: "Media" },
+  { key: "tabActivityMonitor", Icon: PulseLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.ACTIVITY_MONITOR"} defaults="Activity Monitor" />, group: "Media" },
+  { key: "tabJellyfinDevices", Icon: DeviceLineIcon, label: "Authorised Devices", group: "Media" },
+  { key: "tabJellyfinPlugins", Icon: AppsLineIcon, label: "Plugins", group: "Media" },
+  { key: "tabIntegrations", Icon: Plug2LineIcon, label: "Integrations", group: "Connections" },
+  { key: "tabKeys", Icon: Key2LineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.API_KEY"} />, group: "Connections" },
+  { key: "tabWebhooks", Icon: Notification3LineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.WEBHOOKS"} />, group: "Connections" },
+  { key: "tabNotifications", Icon: Notification3LineIcon, label: "Notifications", group: "Connections" },
+  { key: "tabNewsletter", Icon: MailSettingsLineIcon, label: "Newsletter", group: "Connections" },
+  { key: "tabTasks", Icon: TaskLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.TASKS"} />, group: "Operations" },
+  { key: "tabBackup", Icon: ArchiveLineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.BACKUP"} />, group: "Operations" },
+  { key: "tabImports", Icon: Database2LineIcon, label: "Imports", group: "Operations" },
+  { key: "tabHealth", Icon: HeartPulseLineIcon, label: "Health", group: "Operations" },
+  { key: "tabRepair", Icon: ToolsLineIcon, label: "Repair", group: "Operations" },
+  { key: "tabLogs", Icon: FileList3LineIcon, label: <Trans i18nKey={"SETTINGS_PAGE.LOGS"} />, group: "Operations" },
 ];
 
 const settingsTabs = settingsTabItems.map((item) => item.key);
+const settingsTabGroups = settingsTabItems.reduce((groups, item) => {
+  const group = groups.find((entry) => entry.label === item.group);
+  if (group) {
+    group.items.push(item);
+  } else {
+    groups.push({ label: item.group, items: [item] });
+  }
+  return groups;
+}, []);
+const settingsTabItemMap = Object.fromEntries(settingsTabItems.map((item) => [item.key, item]));
+
+function tabTitleFor(key) {
+  const item = settingsTabItemMap[key] || settingsTabItems[0];
+  return tabTitle(item.Icon, item.label);
+}
 const settingsTabHashes = {
   tabGeneral: "general",
   tabSecurity: "security",
@@ -81,9 +104,30 @@ const settingsTabHashes = {
   tabJellyfinDevices: "devices",
   tabJellyfinPlugins: "plugins",
   tabTasks: "tasks",
+  tabKiosk: "kiosk",
   tabLibraries: "libraries",
   tabIntegrations: "integrations",
   tabKeys: "apikeys",
+  tabWebhooks: "webhooks",
+  tabNotifications: "notifications",
+  tabBackup: "backup",
+  tabImports: "imports",
+  tabNewsletter: "newsletter",
+  tabHealth: "health",
+  tabRepair: "repair",
+  tabLogs: "logs",
+};
+const settingsTabPaths = {
+  tabGeneral: "general",
+  tabSecurity: "security",
+  tabActivityMonitor: "activity-monitor",
+  tabJellyfinDevices: "devices",
+  tabJellyfinPlugins: "plugins",
+  tabTasks: "tasks",
+  tabKiosk: "kiosk",
+  tabLibraries: "libraries",
+  tabIntegrations: "integrations",
+  tabKeys: "api-key",
   tabWebhooks: "webhooks",
   tabNotifications: "notifications",
   tabBackup: "backup",
@@ -114,54 +158,122 @@ const settingsHashAliases = {
 };
 const settingsHashToTab = {
   ...Object.fromEntries(Object.entries(settingsTabHashes).map(([key, hash]) => [hash, key])),
+  ...Object.fromEntries(Object.entries(settingsTabPaths).map(([key, slug]) => [slug, key])),
   ...settingsHashAliases,
 };
+const integrationSettingsTabAliases = {
+  media: "media-server",
+  mediaserver: "media-server",
+  "media-server": "media-server",
+  jellyfin: "media-server",
+  arr: "automation",
+  arrapps: "automation",
+  "arr-apps": "automation",
+  automation: "automation",
+  jellyseerr: "seerr",
+  overseerr: "seerr",
+  seerr: "seerr",
+  download: "downloads",
+  downloads: "downloads",
+  "download-clients": "downloads",
+  clients: "downloads",
+  invite: "invites",
+  invites: "invites",
+  "invites-transcodes": "invites",
+  transcodes: "invites",
+  tdarr: "invites",
+};
 
-function normalizeSettingsHash(hash = "") {
-  return String(hash).replace(/^#/, "").trim().toLowerCase();
+function normalizeSettingsSlug(value = "") {
+  return String(value).replace(/^#\/?/, "").trim().toLowerCase();
 }
 
-function getTabFromHash() {
-  return settingsHashToTab[normalizeSettingsHash(window.location.hash)] || "";
+function normalizeIntegrationSettingsTabSlug(value = "") {
+  const normalized = normalizeSettingsSlug(value);
+  return integrationSettingsTabAliases[normalized] || "";
 }
 
-function getSettingsInitialTab() {
-  const hashTab = getTabFromHash();
+function getTabFromHash(hash = window.location.hash) {
+  return settingsHashToTab[normalizeSettingsSlug(hash)] || "";
+}
+
+function getSettingsPathParts(pathname = window.location.pathname) {
+  const parts = pathname.split("/").filter(Boolean);
+  const settingsIndex = parts.findIndex((part) => part.toLowerCase() === "settings");
+  return settingsIndex >= 0 ? parts.slice(settingsIndex + 1) : [];
+}
+
+function getTabFromPath(pathname = window.location.pathname) {
+  const [tabSlug] = getSettingsPathParts(pathname);
+  return settingsHashToTab[normalizeSettingsSlug(tabSlug)] || "";
+}
+
+function getSettingsIntegrationPathTab(pathname = window.location.pathname) {
+  const [tabSlug, integrationTabSlug] = getSettingsPathParts(pathname);
+  const tabName = settingsHashToTab[normalizeSettingsSlug(tabSlug)];
+  return tabName === "tabIntegrations" ? normalizeIntegrationSettingsTabSlug(integrationTabSlug) : "";
+}
+
+function getSettingsInitialTab(location = window.location) {
+  const pathTab = getTabFromPath(location.pathname);
+  if (settingsTabs.includes(pathTab)) return pathTab;
+
+  const hashTab = getTabFromHash(location.hash);
   if (settingsTabs.includes(hashTab)) return hashTab;
 
-  const requestedTab = new URLSearchParams(window.location.search).get("tab");
+  const requestedTab = new URLSearchParams(location.search).get("tab");
   if (settingsTabs.includes(requestedTab)) return requestedTab;
 
   const savedTab = localStorage.getItem(`PREF_SETTINGS_LAST_SELECTED_TAB`) ?? "tabGeneral";
   return settingsTabs.includes(savedTab) ? savedTab : "tabGeneral";
 }
 
-function setSettingsHash(tabName, mode = "replace") {
-  const nextHash = settingsTabHashes[tabName] || settingsTabHashes.tabGeneral;
-  const nextUrl = `${window.location.pathname}${window.location.search}#${nextHash}`;
-  if (window.location.hash === `#${nextHash}`) return;
-  window.history[mode === "push" ? "pushState" : "replaceState"](null, "", nextUrl);
+function getSettingsPath(tabName, integrationTab = "") {
+  const tabSlug = settingsTabPaths[tabName] || settingsTabPaths.tabGeneral;
+  const integrationSlug = tabName === "tabIntegrations" ? normalizeIntegrationSettingsTabSlug(integrationTab) : "";
+  return integrationSlug ? `/settings/${tabSlug}/${integrationSlug}` : `/settings/${tabSlug}`;
 }
 
 export default function Settings() {
-  const [activeTab, setActiveTab] = useState(getSettingsInitialTab);
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState(() => getSettingsInitialTab(location));
+  const [activeIntegrationTab, setActiveIntegrationTab] = useState(() => getSettingsIntegrationPathTab(location.pathname) || "media-server");
 
   useEffect(() => {
-    setSettingsHash(activeTab);
-  }, []);
+    const nextTab = getSettingsInitialTab(location);
+    const nextIntegrationTab = getSettingsIntegrationPathTab(location.pathname) || normalizeIntegrationSettingsTabSlug(location.hash) || "media-server";
+    if (settingsTabs.includes(nextTab)) {
+      setActiveTab(nextTab);
+      localStorage.setItem(`PREF_SETTINGS_LAST_SELECTED_TAB`, nextTab);
+    }
+    if (nextTab === "tabIntegrations") {
+      setActiveIntegrationTab(nextIntegrationTab);
+    }
+  }, [location]);
 
   useEffect(() => {
-    function handleHashChange() {
-      const hashTab = getTabFromHash();
-      if (settingsTabs.includes(hashTab)) {
-        setActiveTab(hashTab);
-        localStorage.setItem(`PREF_SETTINGS_LAST_SELECTED_TAB`, hashTab);
-      }
+    const pathTab = getTabFromPath(location.pathname);
+    if (settingsTabs.includes(pathTab)) return;
+
+    const hashTab = getTabFromHash(location.hash);
+    if (settingsTabs.includes(hashTab)) {
+      const hashIntegrationTab = hashTab === "tabIntegrations" ? normalizeIntegrationSettingsTabSlug(location.hash) || activeIntegrationTab : "";
+      navigate(getSettingsPath(hashTab, hashIntegrationTab), { replace: true });
+      return;
     }
 
-    window.addEventListener("hashchange", handleHashChange);
-    return () => window.removeEventListener("hashchange", handleHashChange);
-  }, []);
+    if (location.pathname === "/settings") {
+      const requestedTab = new URLSearchParams(location.search).get("tab");
+      if (settingsTabs.includes(requestedTab)) {
+        navigate(getSettingsPath(requestedTab), { replace: true });
+        return;
+      }
+      if (!location.hash) {
+        navigate(getSettingsPath(activeTab, activeIntegrationTab), { replace: true });
+      }
+    }
+  }, [activeIntegrationTab, activeTab, location.hash, location.pathname, location.search, navigate]);
 
   function setTab(tabName, updateMode = "push") {
     if (!settingsTabs.includes(tabName)) {
@@ -169,21 +281,140 @@ export default function Settings() {
     }
     setActiveTab(tabName);
     localStorage.setItem(`PREF_SETTINGS_LAST_SELECTED_TAB`, tabName);
-    setSettingsHash(tabName, updateMode);
+    navigate(getSettingsPath(tabName, activeIntegrationTab), { replace: updateMode === "replace" });
+  }
+
+  function setIntegrationTab(tabName) {
+    const nextTab = normalizeIntegrationSettingsTabSlug(tabName) || "media-server";
+    setActiveIntegrationTab(nextTab);
+    navigate(getSettingsPath("tabIntegrations", nextTab));
+  }
+
+  function renderActiveSettingsPane() {
+    switch (activeTab) {
+      case "tabSecurity":
+        return (
+          <SettingsPane>
+            <SecuritySettings />
+          </SettingsPane>
+        );
+      case "tabKiosk":
+        return (
+          <SettingsPane>
+            <KioskSettings />
+          </SettingsPane>
+        );
+      case "tabLibraries":
+        return (
+          <SettingsPane>
+            <LibrarySelector />
+          </SettingsPane>
+        );
+      case "tabActivityMonitor":
+        return (
+          <SettingsPane>
+            <ActivityMonitorSettings />
+          </SettingsPane>
+        );
+      case "tabJellyfinDevices":
+        return (
+          <SettingsPane>
+            <JellyfinAdminSettings view="devices" />
+          </SettingsPane>
+        );
+      case "tabJellyfinPlugins":
+        return (
+          <SettingsPane>
+            <JellyfinAdminSettings view="plugins" />
+          </SettingsPane>
+        );
+      case "tabIntegrations":
+        return (
+          <SettingsPane>
+            <Integrations embedded activeTab={activeIntegrationTab} onTabChange={setIntegrationTab} />
+          </SettingsPane>
+        );
+      case "tabKeys":
+        return (
+          <SettingsPane>
+            <ApiKeys />
+          </SettingsPane>
+        );
+      case "tabWebhooks":
+        return (
+          <SettingsPane>
+            <WebhooksSettings />
+          </SettingsPane>
+        );
+      case "tabNotifications":
+        return (
+          <SettingsPane>
+            <NotificationSettings />
+          </SettingsPane>
+        );
+      case "tabNewsletter":
+        return (
+          <SettingsPane>
+            <NewsletterSettings />
+          </SettingsPane>
+        );
+      case "tabTasks":
+        return (
+          <SettingsPane>
+            <Tasks />
+          </SettingsPane>
+        );
+      case "tabBackup":
+        return (
+          <SettingsPane>
+            <BackupPage />
+          </SettingsPane>
+        );
+      case "tabImports":
+        return (
+          <Tabs defaultActiveKey="jellystat" variant="pills" className="settings-import-tabs" transition={false} mountOnEnter>
+            <Tab eventKey="jellystat" title="Jellystat" className="settings-import-pane">
+              <SettingsPane>
+                <JellystatImport />
+              </SettingsPane>
+            </Tab>
+            <Tab eventKey="tautulli" title="Tautulli" className="settings-import-pane">
+              <SettingsPane>
+                <TautulliImport />
+              </SettingsPane>
+            </Tab>
+          </Tabs>
+        );
+      case "tabHealth":
+        return (
+          <SettingsPane>
+            <HealthSettings />
+          </SettingsPane>
+        );
+      case "tabRepair":
+        return (
+          <SettingsPane>
+            <RepairHub embedded />
+          </SettingsPane>
+        );
+      case "tabLogs":
+        return (
+          <SettingsPane>
+            <Logs />
+          </SettingsPane>
+        );
+      case "tabGeneral":
+      default:
+        return (
+          <SettingsPane>
+            <SettingsConfig />
+          </SettingsPane>
+        );
+    }
   }
 
   return (
     <div className="settings has-mobile-settings-menu">
-      <div className="settings-page-header">
-        <div>
-          <p className="settings-eyebrow">Control center</p>
-          <h1>
-            <Trans i18nKey={"SETTINGS_PAGE.SETTINGS"} />
-          </h1>
-          <p>Configure JellyGlance sync, security, libraries, keys, backups, and logs.</p>
-        </div>
-      </div>
-
       <div className="settings-mobile-menu">
         <div className="settings-mobile-menu-list" role="tablist" aria-label="Settings sections">
           {settingsTabItems.map(({ key, Icon, label }) => (
@@ -201,194 +432,31 @@ export default function Settings() {
         </div>
       </div>
 
-      <Tabs
-        defaultActiveKey={activeTab}
-        activeKey={activeTab}
-        onSelect={setTab}
-        variant="pills"
-        transition={false}
-        mountOnEnter
-        unmountOnExit
-      >
-        <Tab
-          eventKey="tabGeneral"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(Settings3LineIcon, settingsTabItems[0].label)}
-        >
-          <SettingsPane>
-            <SettingsConfig />
-          </SettingsPane>
-        </Tab>
+      <nav className="nav nav-pills settings-sidebar-nav" role="tablist" aria-label="Settings sections">
+        {settingsTabGroups.map((group) => (
+          <div className="settings-sidebar-group" key={group.label}>
+            <span className="settings-sidebar-category">{group.label}</span>
+            {group.items.map(({ key }) => (
+              <button
+                key={key}
+                type="button"
+                className={`nav-link ${activeTab === key ? "active" : ""}`.trim()}
+                onClick={() => setTab(key)}
+                role="tab"
+                aria-selected={activeTab === key}
+              >
+                {tabTitleFor(key)}
+              </button>
+            ))}
+          </div>
+        ))}
+      </nav>
 
-        <Tab
-          eventKey="tabSecurity"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(ShieldKeyholeLineIcon, settingsTabItems[1].label)}
-        >
-          <SettingsPane>
-            <SecuritySettings />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabActivityMonitor"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(PulseLineIcon, settingsTabItems[2].label)}
-        >
-          <SettingsPane>
-            <ActivityMonitorSettings />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabJellyfinDevices"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(DeviceLineIcon, settingsTabItems[3].label)}
-        >
-          <SettingsPane>
-            <JellyfinAdminSettings view="devices" />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabJellyfinPlugins"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(AppsLineIcon, settingsTabItems[4].label)}
-        >
-          <SettingsPane>
-            <JellyfinAdminSettings view="plugins" />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabTasks"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(TaskLineIcon, settingsTabItems[5].label)}
-        >
-          <SettingsPane>
-            <Tasks />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabLibraries"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(GalleryLineIcon, settingsTabItems[6].label)}
-        >
-          <SettingsPane>
-            <LibrarySelector />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabIntegrations"
-          className="settings-tab-pane bg-transparent integrations-settings-tab"
-          title={tabTitle(Plug2LineIcon, settingsTabItems[7].label)}
-        >
-          <SettingsPane>
-            <Integrations embedded />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabKeys"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(Key2LineIcon, settingsTabItems[8].label)}
-        >
-          <SettingsPane>
-            <ApiKeys />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabWebhooks"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(Notification3LineIcon, settingsTabItems[9].label)}
-        >
-          <SettingsPane>
-            <WebhooksSettings />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabNotifications"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(Notification3LineIcon, settingsTabItems[10].label)}
-        >
-          <SettingsPane>
-            <NotificationSettings />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabBackup"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(ArchiveLineIcon, settingsTabItems[11].label)}
-        >
-          <SettingsPane>
-            <BackupPage />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabImports"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(Database2LineIcon, settingsTabItems[12].label)}
-        >
-          <Tabs defaultActiveKey="jellystat" variant="pills" className="settings-import-tabs" transition={false} mountOnEnter>
-            <Tab eventKey="jellystat" title="Jellystat" className="settings-import-pane">
-              <SettingsPane>
-                <JellystatImport />
-              </SettingsPane>
-            </Tab>
-            <Tab eventKey="tautulli" title="Tautulli" className="settings-import-pane">
-              <SettingsPane>
-                <TautulliImport />
-              </SettingsPane>
-            </Tab>
-          </Tabs>
-        </Tab>
-
-        <Tab
-          eventKey="tabNewsletter"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(MailSettingsLineIcon, settingsTabItems[13].label)}
-        >
-          <SettingsPane>
-            <NewsletterSettings />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabHealth"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(HeartPulseLineIcon, settingsTabItems[14].label)}
-        >
-          <SettingsPane>
-            <HealthSettings />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabRepair"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(ToolsLineIcon, settingsTabItems[15].label)}
-        >
-          <SettingsPane>
-            <RepairHub embedded />
-          </SettingsPane>
-        </Tab>
-
-        <Tab
-          eventKey="tabLogs"
-          className="settings-tab-pane bg-transparent"
-          title={tabTitle(FileList3LineIcon, settingsTabItems[16].label)}
-        >
-          <SettingsPane>
-            <Logs />
-          </SettingsPane>
-        </Tab>
-      </Tabs>
+      <div className="tab-content">
+        <div className={`settings-tab-pane bg-transparent tab-pane active show ${activeTab === "tabIntegrations" ? "integrations-settings-tab" : ""}`.trim()}>
+          {renderActiveSettingsPane()}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/pages/statistics.jsx
+++ b/apps/web/src/pages/statistics.jsx
@@ -1,8 +1,15 @@
 import { Tabs, Tab } from "react-bootstrap";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import axios from "../lib/axios_instance";
 import BarChartFillIcon from "remixicon-react/BarChartFillIcon";
 import CalendarLineIcon from "remixicon-react/CalendarLineIcon";
+import ComputerLineIcon from "remixicon-react/ComputerLineIcon";
+import FilmLineIcon from "remixicon-react/FilmLineIcon";
 import PulseLineIcon from "remixicon-react/PulseLineIcon";
+import TimeLineIcon from "remixicon-react/TimeLineIcon";
+import TvLineIcon from "remixicon-react/TvLineIcon";
+import UserStarLineIcon from "remixicon-react/UserStarLineIcon";
 
 import "./css/stats.css";
 
@@ -11,6 +18,226 @@ import PlayStatsByDay from "./components/statistics/play-stats-by-day";
 import PlayStatsByHour from "./components/statistics/play-stats-by-hour";
 import HomeStatisticCards from "./components/HomeStatisticCards";
 import { Trans } from "react-i18next";
+
+function getStatValue(item = {}) {
+  return Number(item.Plays ?? item.Count ?? item.unique_viewers ?? 0);
+}
+
+function getMediaItemId(item = {}) {
+  return item.Id || item.ItemId || item.NowPlayingItemId || item.jellyglanceItemId || "";
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat().format(Number(value || 0));
+}
+
+function StatsRankList({ title, icon, items, emptyText }) {
+  return (
+    <article className="stats-rank-panel">
+      <header>
+        <div>{icon}</div>
+        <span>{title}</span>
+      </header>
+      <div className="stats-rank-list">
+        {items.length ? (
+          items.slice(0, 5).map((item, index) => {
+            const mediaItemId = getMediaItemId(item);
+            const content = (
+              <>
+                <small>{index + 1}</small>
+                <strong>{item.Name || item.Client || "Unknown"}</strong>
+                <span>{formatNumber(getStatValue(item))}</span>
+              </>
+            );
+
+            return mediaItemId ? (
+              <Link key={mediaItemId} to={`/libraries/item/${mediaItemId}`} className="stats-rank-row">
+                {content}
+              </Link>
+            ) : (
+              <div key={item.Name || index} className="stats-rank-row">
+                {content}
+              </div>
+            );
+          })
+        ) : (
+          <p>{emptyText}</p>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function StatsOverview({ days }) {
+  const [overview, setOverview] = useState({
+    movies: [],
+    series: [],
+    libraries: [],
+    users: [],
+    clients: [],
+    methods: [],
+  });
+  const [status, setStatus] = useState("loading");
+  const token = localStorage.getItem("token");
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function fetchOverview() {
+      setStatus("loading");
+
+      try {
+        const headers = {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        };
+        const requests = [
+          axios.post("/stats/getMostViewedByType", { days, type: "Movie" }, { headers }),
+          axios.post("/stats/getMostViewedByType", { days, type: "Series" }, { headers }),
+          axios.post("/stats/getMostViewedLibraries", { days }, { headers }),
+          axios.post("/stats/getMostActiveUsers", { days }, { headers }),
+          axios.post("/stats/getMostUsedClient", { days }, { headers }),
+          axios.post("/stats/getPlaybackMethodStats", { days }, { headers }),
+        ];
+
+        const [movies, series, libraries, users, clients, methods] = await Promise.all(requests);
+
+        if (!ignore) {
+          setOverview({
+            movies: movies.data || [],
+            series: series.data || [],
+            libraries: libraries.data || [],
+            users: users.data || [],
+            clients: clients.data || [],
+            methods: methods.data || [],
+          });
+          setStatus("loaded");
+        }
+      } catch (error) {
+        console.log(error);
+        if (!ignore) setStatus("error");
+      }
+    }
+
+    fetchOverview();
+    const intervalId = setInterval(fetchOverview, 60000 * 5);
+
+    return () => {
+      ignore = true;
+      clearInterval(intervalId);
+    };
+  }, [days, token]);
+
+  const metrics = useMemo(() => {
+    const totalMovies = overview.movies.reduce((sum, item) => sum + getStatValue(item), 0);
+    const totalSeries = overview.series.reduce((sum, item) => sum + getStatValue(item), 0);
+    const totalMethods = overview.methods.reduce((sum, item) => sum + getStatValue(item), 0);
+    const directPlays = overview.methods
+      .filter((item) => String(item.Name).toLowerCase() === "directplay")
+      .reduce((sum, item) => sum + getStatValue(item), 0);
+    const transcodes = overview.methods
+      .filter((item) => String(item.Name).toLowerCase() === "transcode")
+      .reduce((sum, item) => sum + getStatValue(item), 0);
+
+    return {
+      totalPlays: totalMovies + totalSeries,
+      topLibrary: overview.libraries[0],
+      topUser: overview.users[0],
+      topClient: overview.clients[0],
+      directPercent: totalMethods ? Math.round((directPlays / totalMethods) * 100) : 0,
+      transcodePercent: totalMethods ? Math.round((transcodes / totalMethods) * 100) : 0,
+    };
+  }, [overview]);
+
+  const methodTotal = overview.methods.reduce((sum, item) => sum + getStatValue(item), 0);
+  const topCards = [
+    { label: "Top library", value: metrics.topLibrary?.Name || "No data", detail: `${formatNumber(getStatValue(metrics.topLibrary))} plays`, icon: <BarChartFillIcon /> },
+    {
+      label: "Most active user",
+      value: metrics.topUser?.Name || "No data",
+      detail: `${formatNumber(getStatValue(metrics.topUser))} plays`,
+      icon: metrics.topUser?.UserId ? <img src={`/proxy/Users/Images/Primary?id=${metrics.topUser.UserId}&fillWidth=80&quality=80`} alt="" /> : <UserStarLineIcon />,
+    },
+    { label: "Top client", value: metrics.topClient?.Client || metrics.topClient?.Name || "No data", detail: `${formatNumber(getStatValue(metrics.topClient))} plays`, icon: <ComputerLineIcon /> },
+  ];
+
+  return (
+    <section className="stats-overview">
+      <div className="stats-overview-kpis" aria-label="Playback overview">
+        <article>
+          <FilmLineIcon />
+          <span>Total plays</span>
+          <strong>{status === "loading" ? "..." : formatNumber(metrics.totalPlays)}</strong>
+        </article>
+        <article>
+          <TvLineIcon />
+          <span>Direct play</span>
+          <strong>{status === "loading" ? "..." : `${metrics.directPercent}%`}</strong>
+        </article>
+        <article>
+          <PulseLineIcon />
+          <span>Transcode</span>
+          <strong>{status === "loading" ? "..." : `${metrics.transcodePercent}%`}</strong>
+        </article>
+        <article>
+          <TimeLineIcon />
+          <span>Window</span>
+          <strong>{days} days</strong>
+        </article>
+      </div>
+
+      {status === "error" ? <div className="stats-overview-error">Unable to load overview statistics.</div> : null}
+
+      <div className="stats-overview-grid">
+        <div className="stats-overview-panel stats-overview-panel-primary">
+          <div className="stats-leader-grid">
+            {topCards.map((card) => (
+              <article key={card.label} className="stats-leader-card">
+                <div>{card.icon}</div>
+                <span>{card.label}</span>
+                <strong>{card.value}</strong>
+                <small>{card.detail}</small>
+              </article>
+            ))}
+          </div>
+          <div className="stats-rank-grid">
+            <StatsRankList title="Movies" icon={<FilmLineIcon />} items={overview.movies} emptyText="No movie plays in this window." />
+            <StatsRankList title="Shows" icon={<TvLineIcon />} items={overview.series} emptyText="No show plays in this window." />
+          </div>
+        </div>
+
+        <div className="stats-overview-panel stats-method-panel">
+          <div className="stats-section-heading">
+            <p>Playback quality</p>
+            <h2>Method split</h2>
+          </div>
+          <div className="stats-method-list">
+            {overview.methods.length ? (
+              overview.methods.map((method) => {
+                const value = getStatValue(method);
+                const percent = methodTotal ? Math.round((value / methodTotal) * 100) : 0;
+                return (
+                  <div key={method.Name} className="stats-method-row">
+                    <span>{String(method.Name).replace("DirectPlay", "Direct Play").replace("DirectStream", "Direct Stream")}</span>
+                    <strong>{formatNumber(value)}</strong>
+                    <div>
+                      <i style={{ width: `${percent}%` }} />
+                    </div>
+                    <small>{percent}%</small>
+                  </div>
+                );
+              })
+            ) : (
+              <div className="stats-overview-empty">No playback method data for this window.</div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <HomeStatisticCards days={days} variant="media-rankings" />
+    </section>
+  );
+}
 
 function Statistics() {
   const presets = [7, 30, 90];
@@ -26,7 +253,8 @@ function Statistics() {
     localStorage.setItem("PREF_STATISTICS_STAT_DAYS_INPUT", event.target.value);
   };
 
-  const [activeTab, setActiveTab] = useState(localStorage.getItem(`PREF_STATISTICS_LAST_SELECTED_TAB`) ?? "tabCount");
+  const storedTab = localStorage.getItem(`PREF_STATISTICS_LAST_SELECTED_TAB`);
+  const [activeTab, setActiveTab] = useState(storedTab === "tabDuration" || storedTab === "tabCount" ? storedTab : "tabOverview");
 
   function setTab(tabName) {
     setActiveTab(tabName);
@@ -47,7 +275,11 @@ function Statistics() {
     }
   };
 
-  const modeLabel = activeTab === "tabCount" ? "Count view" : "Duration view";
+  const chartTitle = activeTab === "tabCount" ? "Playback counts" : "Watch duration";
+  const chartDescription =
+    activeTab === "tabCount"
+      ? "Play count trends split by library, weekday, and hour."
+      : "Watch-time trends split by library, weekday, and hour.";
 
   return (
     <div className="watch-stats">
@@ -68,6 +300,8 @@ function Statistics() {
         <div className="stats-controls">
           <div className="stats-tab-nav">
             <Tabs defaultActiveKey={activeTab} activeKey={activeTab} onSelect={setTab} variant="pills">
+              <Tab eventKey="tabOverview" className="bg-transparent" title="Overview" />
+
               <Tab eventKey="tabCount" className="bg-transparent" title={<Trans i18nKey="STAT_PAGE.COUNT_VIEW" />} />
 
               <Tab eventKey="tabDuration" className="bg-transparent" title={<Trans i18nKey="STAT_PAGE.DURATION_VIEW" />} />
@@ -105,57 +339,28 @@ function Statistics() {
         </div>
       </div>
 
-      <div className="stats-summary-strip" aria-label="Statistics filters">
-        <div>
-          <PulseLineIcon />
-          <span>Mode</span>
-          <strong>{modeLabel}</strong>
-        </div>
-        <div>
-          <CalendarLineIcon />
-          <span>Window</span>
-          <strong>
-            {days} <Trans i18nKey={`UNITS.DAY${days > 1 ? "S" : ""}`} />
-          </strong>
-        </div>
-        <div>
-          <BarChartFillIcon />
-          <span>Refresh</span>
-          <strong>Every 5 minutes</strong>
-        </div>
-      </div>
+      <main className="stats-workbench">
+        {activeTab === "tabOverview" && <StatsOverview days={days} />}
 
-      <div className="statistics-dashboard">
-        <HomeStatisticCards days={days} />
-      </div>
-
-      {activeTab === "tabCount" && (
-        <div className="statistics-dashboard">
-          <div className="stats-section-heading">
-            <p>Charts</p>
-            <h2>Playback Over Time</h2>
+        {(activeTab === "tabCount" || activeTab === "tabDuration") && (
+          <div className="statistics-dashboard">
+            <div className="stats-chart-intro">
+              <div>
+                <p>Charts</p>
+                <h2>{chartTitle}</h2>
+                <span>{chartDescription}</span>
+              </div>
+              <strong>{days} day window</strong>
+            </div>
+            <DailyPlayStats days={days} viewName={activeTab === "tabCount" ? "count" : "duration"} />
+            <div className="statistics-graphs">
+              <PlayStatsByDay days={days} viewName={activeTab === "tabCount" ? "count" : "duration"} />
+              <PlayStatsByHour days={days} viewName={activeTab === "tabCount" ? "count" : "duration"} />
+            </div>
+            <HomeStatisticCards days={days} variant="media-rankings" />
           </div>
-          <DailyPlayStats days={days} viewName="count" />
-          <div className="statistics-graphs">
-            <PlayStatsByDay days={days} viewName="count" />
-            <PlayStatsByHour days={days} viewName="count" />
-          </div>
-        </div>
-      )}
-
-      {activeTab === "tabDuration" && (
-        <div className="statistics-dashboard">
-          <div className="stats-section-heading">
-            <p>Charts</p>
-            <h2>Playback Duration</h2>
-          </div>
-          <DailyPlayStats days={days} viewName="duration" />
-          <div className="statistics-graphs">
-            <PlayStatsByDay days={days} viewName="duration" />
-            <PlayStatsByHour days={days} viewName="duration" />
-          </div>
-        </div>
-      )}
+        )}
+      </main>
     </div>
   );
 }

--- a/apps/web/src/pages/users.jsx
+++ b/apps/web/src/pages/users.jsx
@@ -6,6 +6,8 @@ import CryptoJS from "crypto-js";
 import AccountCircleFillIcon from "remixicon-react/AccountCircleFillIcon";
 import CheckFillIcon from "remixicon-react/CheckFillIcon";
 import CloseFillIcon from "remixicon-react/CloseFillIcon";
+import EyeLineIcon from "remixicon-react/EyeLineIcon";
+import EyeOffLineIcon from "remixicon-react/EyeOffLineIcon";
 import SearchLineIcon from "remixicon-react/SearchLineIcon";
 import DeleteBinLineIcon from "remixicon-react/DeleteBinLineIcon";
 import LockPasswordLineIcon from "remixicon-react/LockPasswordLineIcon";
@@ -22,6 +24,13 @@ import Loading from "./components/general/loading";
 import i18next from "i18next";
 
 const token = localStorage.getItem("token");
+const PERMISSION_DEFINITIONS = [
+  { key: "dashboard", label: "Dashboard", detail: "Can open JellyGlance and view dashboards." },
+  { key: "users", label: "Users", detail: "Can manage user roles, tracking, and local accounts." },
+  { key: "settings", label: "Settings", detail: "Can change integrations, backups, imports, and maintenance settings." },
+  { key: "apiKeys", label: "API Keys", detail: "Can view and manage API keys." },
+];
+const LOCKED_PERMISSION_ROLES = new Set(["Owner", "Disabled"]);
 
 function formatWatchTime(seconds = 0) {
   const hours = Math.floor(seconds / 3600);
@@ -49,7 +58,7 @@ function formatLastSeen(time) {
 
 function userImage(user, size = 48) {
   if (user.PrimaryImageTag) {
-    return <img className="users-avatar" src={`proxy/Users/Images/Primary?id=${user.UserId}&quality=70`} alt="" style={{ width: size, height: size }} />;
+    return <img className="users-avatar" src={`proxy/Users/Images/Primary?id=${user.UserId}&quality=70`} alt="" loading="lazy" decoding="async" style={{ width: size, height: size }} />;
   }
 
   return (
@@ -77,6 +86,8 @@ export default function Users() {
   const [searchQuery, setSearchQuery] = useState("");
   const [roleFilter, setRoleFilter] = useState("All");
   const [sourceFilter, setSourceFilter] = useState("All");
+  const [viewMode, setViewMode] = useState(localStorage.getItem("PREF_USERS_ViewMode") || "cards");
+  const [showHiddenUsers, setShowHiddenUsers] = useState(localStorage.getItem("PREF_USERS_ShowHidden") === "true");
   const [savingUserId, setSavingUserId] = useState("");
   const [alert, setAlert] = useState(null);
   const [showAddUser, setShowAddUser] = useState(false);
@@ -232,6 +243,7 @@ export default function Users() {
     return rows
       .filter((user) => roleFilter === "All" || user.Role === roleFilter)
       .filter((user) => sourceFilter === "All" || user.Source === sourceFilter)
+      .filter((user) => showHiddenUsers || user.Source !== "Jellyfin" || user.Tracked)
       .filter((user) => {
         if (!searchQuery) {
           return true;
@@ -246,11 +258,12 @@ export default function Users() {
         );
       })
       .sort((a, b) => (b.SortWatchTime || 0) - (a.SortWatchTime || 0));
-  }, [roleFilter, rows, searchQuery, sourceFilter]);
+  }, [roleFilter, rows, searchQuery, showHiddenUsers, sourceFilter]);
 
   const visibleRows = filteredRows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
   const jellyfinRows = rows.filter((user) => user.Source === "Jellyfin");
   const trackedCount = jellyfinRows.filter((user) => user.Tracked).length;
+  const hiddenUserCount = jellyfinRows.length - trackedCount;
   const totalWatchTime = jellyfinRows.reduce((total, user) => total + Number(user.TotalWatchTime || 0), 0);
   const localAccountCount = rows.filter((user) => user.Source === "Local").length;
   const oidcAccountCount = rows.filter((user) => user.Source === "OIDC").length;
@@ -264,21 +277,30 @@ export default function Users() {
       ...(access.rolePermissions?.[previewRole] || {}),
     };
   }, [access, previewRole]);
+  const selectedRolePermissions = previewPermissions;
+  const selectedRoleLocked = LOCKED_PERMISSION_ROLES.has(previewRole);
 
   async function toggleTrackedState(userid) {
-    const response = await axios.post(
-      "/api/setUntrackedUsers",
-      { userId: userid },
-      { headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } }
-    );
+    try {
+      setSavingUserId(userid);
+      const response = await axios.post(
+        "/api/setUntrackedUsers",
+        { userId: userid },
+        { headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } }
+      );
 
-    const excluded = response.data;
-    setData((currentData) =>
-      currentData.map((item) => ({
-        ...item,
-        Tracked: !excluded.includes(item.UserId),
-      }))
-    );
+      const excluded = response.data;
+      setData((currentData) =>
+        currentData.map((item) => ({
+          ...item,
+          Tracked: !excluded.includes(item.UserId),
+        }))
+      );
+    } catch (error) {
+      setAlert({ variant: "danger", message: error.response?.data?.errorMessage || "Unable to update tracking." });
+    } finally {
+      setSavingUserId("");
+    }
   }
 
   async function changeJellyfinRole(userid, role) {
@@ -381,20 +403,21 @@ export default function Users() {
       [permission]: enabled,
     };
 
-    setAccess((currentAccess) => ({
-      ...currentAccess,
-      rolePermissions: {
-        ...(currentAccess.rolePermissions || {}),
-        [role]: nextPermissions,
-      },
-    }));
+    if (LOCKED_PERMISSION_ROLES.has(role)) return;
 
     try {
-      await axios.patch(
+      const response = await axios.patch(
         `/api/roles/${encodeURIComponent(role)}/permissions`,
         { permissions: nextPermissions },
         { headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } }
       );
+      setAccess((currentAccess) => ({
+        ...currentAccess,
+        rolePermissions: {
+          ...(currentAccess.rolePermissions || {}),
+          [role]: response.data.permissions,
+        },
+      }));
     } catch (error) {
       setAlert({ variant: "danger", message: error.response?.data?.errorMessage || "Unable to update permissions." });
       await fetchAccess();
@@ -402,16 +425,24 @@ export default function Users() {
   }
 
   async function changeLocalRole(user, role) {
-    const response = await axios.patch(
-      `/api/localUsers/${user.id}`,
-      { role },
-      { headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } }
-    );
+    try {
+      setSavingUserId(`local-${user.id}`);
+      const response = await axios.patch(
+        `/api/localUsers/${user.id}`,
+        { role },
+        { headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } }
+      );
 
-    setAccess((currentAccess) => ({
-      ...currentAccess,
-      localUsers: currentAccess.localUsers.map((localUser) => (localUser.id === user.id ? response.data : localUser)),
-    }));
+      setAccess((currentAccess) => ({
+        ...currentAccess,
+        localUsers: currentAccess.localUsers.map((localUser) => (localUser.id === user.id ? response.data : localUser)),
+      }));
+      setAlert({ variant: "success", message: "Local role updated." });
+    } catch (error) {
+      setAlert({ variant: "danger", message: error.response?.data?.errorMessage || "Unable to update local role." });
+    } finally {
+      setSavingUserId("");
+    }
   }
 
   async function removeLocalUser(user) {
@@ -452,6 +483,90 @@ export default function Users() {
     setResetPassword("");
     setResetTarget(null);
     setAlert({ variant: "success", message: "Password reset." });
+  }
+
+  function updateViewMode(nextMode) {
+    setViewMode(nextMode);
+    localStorage.setItem("PREF_USERS_ViewMode", nextMode);
+  }
+
+  function updateShowHiddenUsers(nextValue) {
+    setShowHiddenUsers(nextValue);
+    localStorage.setItem("PREF_USERS_ShowHidden", String(nextValue));
+    setPage(0);
+  }
+
+  function renderRoleControl(user) {
+    if (user.IsLocalAccount && !user.IsPrimaryLocal) {
+      return (
+        <FormSelect className="users-role-select" value={user.Role} onChange={(event) => changeLocalRole(user.LocalUser, event.target.value)} disabled={savingUserId === `local-${user.LocalUser.id}`}>
+          {access.roles.map((role) => (
+            <option key={role} value={role}>
+              {role}
+            </option>
+          ))}
+        </FormSelect>
+      );
+    }
+
+    if (user.Source === "Jellyfin") {
+      return (
+        <FormSelect className="users-role-select" value={user.Role} onChange={(event) => changeJellyfinRole(user.UserId, event.target.value)} disabled={savingUserId === user.UserId}>
+          {access.roles.map((role) => (
+            <option key={role} value={role}>
+              {role}
+            </option>
+          ))}
+        </FormSelect>
+      );
+    }
+
+    return <span className="users-role-readonly">{user.Role}</span>;
+  }
+
+  function renderUserActions(user) {
+    if (user.Source === "Jellyfin") {
+      return (
+        <Button
+          className={`users-track-button ${user.Tracked ? "is-tracked" : ""}`}
+          type="button"
+          onClick={() => toggleTrackedState(user.UserId)}
+          disabled={savingUserId === user.UserId}
+          title={user.Tracked ? "Hide user" : "Unhide user"}
+        >
+          {savingUserId === user.UserId ? <Spinner size="sm" animation="border" /> : user.Tracked ? <EyeLineIcon size={20} /> : <EyeOffLineIcon size={20} />}
+        </Button>
+      );
+    }
+
+    if (user.IsLocalAccount) {
+      return (
+        <div className="users-row-actions">
+          <Button
+            type="button"
+            className="users-row-action-button"
+            title="Reset password"
+            aria-label={`Reset password for ${user.UserName}`}
+            onClick={() => setResetTarget(user.IsPrimaryLocal ? { primary: true, username: user.UserName } : user.LocalUser)}
+          >
+            <LockPasswordLineIcon size={17} />
+          </Button>
+          {!user.IsPrimaryLocal ? (
+            <Button
+              type="button"
+              className="users-row-action-button is-danger"
+              title="Delete local user"
+              aria-label={`Delete ${user.UserName}`}
+              onClick={() => setDeleteTarget(user.LocalUser)}
+            >
+              <DeleteBinLineIcon size={17} />
+            </Button>
+          ) : null}
+        </div>
+      );
+    }
+
+    return <span className="users-track-placeholder" />;
   }
 
   if (!data || !config || !access) {
@@ -520,6 +635,14 @@ export default function Users() {
               <p>{formatWatchTime(totalWatchTime)} watched across synced users.</p>
             </div>
             <div className="users-toolbar">
+              <div className="users-view-toggle" role="group" aria-label="User view">
+                <button type="button" className={viewMode === "cards" ? "is-active" : ""} onClick={() => updateViewMode("cards")}>
+                  Cards
+                </button>
+                <button type="button" className={viewMode === "list" ? "is-active" : ""} onClick={() => updateViewMode("list")}>
+                  List
+                </button>
+              </div>
               <div className="users-search">
                 <SearchLineIcon size={17} />
                 <FormControl type="text" placeholder="Search users, media, clients" value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} />
@@ -551,108 +674,102 @@ export default function Users() {
                 <option value="25">25 rows</option>
                 <option value="50">50 rows</option>
               </FormSelect>
+              <label className="users-hidden-toggle">
+                <Form.Check type="switch" checked={showHiddenUsers} onChange={(event) => updateShowHiddenUsers(event.target.checked)} />
+                <span>Show hidden</span>
+                <small>{hiddenUserCount}</small>
+              </label>
             </div>
           </div>
 
-          <div className="users-list">
-            {visibleRows.map((user) => (
-              <article className={`users-row-card ${user.Source !== "Jellyfin" ? "is-account-row" : ""}`} key={user.AccountId}>
-                <div className="users-row-person">
-                  {userImage(user, 54)}
-                  <div>
+          {viewMode === "cards" ? (
+            <div className="users-profile-grid">
+              {visibleRows.map((user) => (
+                <article className={`users-profile-card ${user.Source !== "Jellyfin" ? "is-account-card" : ""} ${!user.Tracked && user.Source === "Jellyfin" ? "is-hidden-user" : ""}`} key={user.AccountId}>
+                  <div className="users-profile-top">
+                    {userImage(user, 72)}
+                    <div className="users-profile-actions">
+                      {renderUserActions(user)}
+                    </div>
+                  </div>
+                  <div className="users-profile-name">
                     {user.Source === "Jellyfin" ? <Link to={`/users/${user.UserId}`}>{user.UserName}</Link> : <strong>{user.UserName}</strong>}
                     <span>{user.SourceLabel}</span>
                   </div>
-                </div>
+                  <div className="users-profile-badges">
+                    <Badge className={`users-role-badge ${roleClass(user.Role)}`}>{user.Role}</Badge>
+                    <Badge className={`users-source-badge ${sourceClass(user.Source)}`}>{user.Source}</Badge>
+                    {user.Source === "Jellyfin" && !user.Tracked ? <Badge className="users-source-badge source-hidden">Hidden</Badge> : null}
+                  </div>
+                  <div className="users-profile-metrics">
+                    <span>
+                      <small>Watch time</small>
+                      <strong>{formatWatchTime(user.TotalWatchTime)}</strong>
+                    </span>
+                    <span>
+                      <small>Last watched</small>
+                      <strong>{user.LastWatched || "Never"}</strong>
+                    </span>
+                    <span>
+                      <small>Client</small>
+                      <strong>{user.LastClient || "N/A"}</strong>
+                    </span>
+                    <span>
+                      <small>{user.IsRunning ? "Watching now" : "Last seen"}</small>
+                      <strong>{user.IsRunning ? "Running" : formatLastSeen(user.LastSeen)}</strong>
+                    </span>
+                  </div>
+                  <div className="users-profile-role">
+                    {renderRoleControl(user)}
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="users-list">
+              {visibleRows.map((user) => (
+                <article className={`users-row-card ${user.Source !== "Jellyfin" ? "is-account-row" : ""} ${!user.Tracked && user.Source === "Jellyfin" ? "is-hidden-user" : ""}`} key={user.AccountId}>
+                  <div className="users-row-person">
+                    {userImage(user, 54)}
+                    <div>
+                      {user.Source === "Jellyfin" ? <Link to={`/users/${user.UserId}`}>{user.UserName}</Link> : <strong>{user.UserName}</strong>}
+                      <span>{user.SourceLabel}</span>
+                    </div>
+                  </div>
 
-                <div className="users-row-metrics">
-                  <div className="users-row-meta">
-                    <span>Last watched</span>
-                    <strong>{user.LastWatched || "Never"}</strong>
+                  <div className="users-row-metrics">
+                    <div className="users-row-meta">
+                      <span>Last watched</span>
+                      <strong>{user.LastWatched || "Never"}</strong>
+                    </div>
+                    <div className="users-row-meta">
+                      <span>Client</span>
+                      <strong>{user.LastClient || "N/A"}</strong>
+                    </div>
+                    <div className="users-row-meta">
+                      <span>Watch time</span>
+                      <strong>{formatWatchTime(user.TotalWatchTime)}</strong>
+                    </div>
+                    <div className="users-row-meta">
+                      <span>{user.IsRunning ? "Watching now" : "Last seen"}</span>
+                      <strong>{user.IsRunning ? "Running" : formatLastSeen(user.LastSeen)}</strong>
+                    </div>
                   </div>
-                  <div className="users-row-meta">
-                    <span>Client</span>
-                    <strong>{user.LastClient || "N/A"}</strong>
-                  </div>
-                  <div className="users-row-meta">
-                    <span>Watch time</span>
-                    <strong>{formatWatchTime(user.TotalWatchTime)}</strong>
-                  </div>
-                  <div className="users-row-meta">
-                    <span>{user.IsRunning ? "Watching now" : "Last seen"}</span>
-                    <strong>{user.IsRunning ? "Running" : formatLastSeen(user.LastSeen)}</strong>
-                  </div>
-                </div>
 
-                <div className="users-row-badges">
-                  <Badge className={`users-role-badge ${roleClass(user.Role)}`}>{user.Role}</Badge>
-                  <Badge className={`users-source-badge ${sourceClass(user.Source)}`}>{user.Source}</Badge>
-                </div>
-
-                {user.IsLocalAccount && !user.IsPrimaryLocal ? (
-                  <FormSelect value={user.Role} onChange={(event) => changeLocalRole(user.LocalUser, event.target.value)}>
-                    {access.roles.map((role) => (
-                      <option key={role} value={role}>
-                        {role}
-                      </option>
-                    ))}
-                  </FormSelect>
-                ) : user.Source === "Jellyfin" ? (
-                  <FormSelect value={user.Role} onChange={(event) => changeJellyfinRole(user.UserId, event.target.value)} disabled={savingUserId === user.UserId}>
-                    {access.roles.map((role) => (
-                      <option key={role} value={role}>
-                        {role}
-                      </option>
-                    ))}
-                  </FormSelect>
-                ) : (
-                  <span className="users-role-readonly">{user.Role}</span>
-                )}
-
-                {user.Source === "Jellyfin" ? (
-                  <Button
-                    className={`users-track-button ${user.Tracked ? "is-tracked" : ""}`}
-                    type="button"
-                    onClick={() => toggleTrackedState(user.UserId)}
-                    title={user.Tracked ? "Tracked" : "Not tracked"}
-                  >
-                    {user.Tracked ? <CheckFillIcon size={18} /> : <CloseFillIcon size={18} />}
-                  </Button>
-                ) : user.IsLocalAccount ? (
-                  <div className="users-row-actions">
-                    <Button
-                      type="button"
-                      className="users-row-action-button"
-                      title="Reset password"
-                      aria-label={`Reset password for ${user.UserName}`}
-                      onClick={() =>
-                        setResetTarget(
-                          user.IsPrimaryLocal
-                            ? { primary: true, username: user.UserName }
-                            : user.LocalUser
-                        )
-                      }
-                    >
-                      <LockPasswordLineIcon size={17} />
-                    </Button>
-                    {!user.IsPrimaryLocal ? (
-                      <Button
-                        type="button"
-                        className="users-row-action-button is-danger"
-                        title="Delete local user"
-                        aria-label={`Delete ${user.UserName}`}
-                        onClick={() => setDeleteTarget(user.LocalUser)}
-                      >
-                        <DeleteBinLineIcon size={17} />
-                      </Button>
-                    ) : null}
+                  <div className="users-row-badges">
+                    <Badge className={`users-role-badge ${roleClass(user.Role)}`}>{user.Role}</Badge>
+                    <Badge className={`users-source-badge ${sourceClass(user.Source)}`}>{user.Source}</Badge>
+                    {user.Source === "Jellyfin" && !user.Tracked ? <Badge className="users-source-badge source-hidden">Hidden</Badge> : null}
                   </div>
-                ) : (
-                  <span className="users-track-placeholder" />
-                )}
-              </article>
-            ))}
-          </div>
+
+                  {renderRoleControl(user)}
+                  {renderUserActions(user)}
+                </article>
+              ))}
+            </div>
+          )}
+
+          {!visibleRows.length ? <div className="users-empty-state">No users match this view.</div> : null}
 
           <div className="users-pagination">
             <span>
@@ -672,6 +789,53 @@ export default function Users() {
           </div>
         </div>
 
+        <aside className="users-panel users-access-panel">
+          <div className="users-panel-header compact">
+            <div>
+              <h2>Permissions</h2>
+              <p>Role access is saved to the backend and checked on protected API routes.</p>
+            </div>
+            <Button className="users-primary-action" onClick={() => setShowRolesManager(true)}>
+              <PriceTag3LineIcon size={17} />
+              Roles
+            </Button>
+          </div>
+
+          <div className="users-role-selector">
+            <span>Editing role</span>
+            <FormSelect value={previewRole} onChange={(event) => setPreviewRole(event.target.value)}>
+              {access.roles.map((role) => (
+                <option key={role} value={role}>
+                  {role}
+                </option>
+              ))}
+            </FormSelect>
+          </div>
+
+          <div className="users-permission-editor">
+            {PERMISSION_DEFINITIONS.map((permission) => (
+              <label className={`users-permission-row ${selectedRolePermissions[permission.key] ? "is-enabled" : ""}`} key={permission.key}>
+                <span>
+                  <strong>{permission.label}</strong>
+                  <small>{permission.detail}</small>
+                </span>
+                <Form.Check
+                  type="switch"
+                  checked={Boolean(selectedRolePermissions[permission.key])}
+                  disabled={selectedRoleLocked}
+                  onChange={(event) => updateRolePermission(previewRole, permission.key, event.target.checked)}
+                  aria-label={`${permission.label} permission for ${previewRole}`}
+                />
+              </label>
+            ))}
+          </div>
+
+          {selectedRoleLocked ? (
+            <p className="users-permission-note">{previewRole === "Owner" ? "Owner always keeps full access." : "Disabled users cannot access JellyGlance."}</p>
+          ) : (
+            <p className="users-permission-note">Changes save immediately and apply the next time that user calls a protected route.</p>
+          )}
+        </aside>
       </section>
 
       <Modal show={showUsersManager} onHide={() => setShowUsersManager(false)} centered size="lg" contentClassName="users-modal users-manager-modal">
@@ -761,15 +925,10 @@ export default function Users() {
               </FormSelect>
             </div>
             <div className="role-preview-grid">
-              {[
-                ["dashboard", "Dashboard"],
-                ["users", "Users"],
-                ["settings", "Settings"],
-                ["apiKeys", "API Keys"],
-              ].map(([permission, label]) => (
-                <span key={permission} className={previewPermissions[permission] ? "is-allowed" : "is-denied"}>
-                  {previewPermissions[permission] ? <CheckFillIcon size={14} /> : <CloseFillIcon size={14} />}
-                  {label}
+              {PERMISSION_DEFINITIONS.map((permission) => (
+                <span key={permission.key} className={previewPermissions[permission.key] ? "is-allowed" : "is-denied"}>
+                  {previewPermissions[permission.key] ? <CheckFillIcon size={14} /> : <CloseFillIcon size={14} />}
+                  {permission.label}
                 </span>
               ))}
             </div>
@@ -788,19 +947,15 @@ export default function Users() {
                     )}
                   </div>
                   <div className="permission-toggle-grid">
-                    {[
-                      ["dashboard", "Dashboard"],
-                      ["users", "Users"],
-                      ["settings", "Settings"],
-                      ["apiKeys", "API Keys"],
-                    ].map(([permission, label]) => (
+                    {PERMISSION_DEFINITIONS.map((permission) => (
                       <Form.Check
-                        key={permission}
+                        key={permission.key}
                         type="switch"
-                        id={`role-${role}-${permission}`}
-                        label={label}
-                        checked={Boolean(access.rolePermissions?.[role]?.[permission])}
-                        onChange={(event) => updateRolePermission(role, permission, event.target.checked)}
+                        id={`role-${role}-${permission.key}`}
+                        label={permission.label}
+                        checked={Boolean(access.rolePermissions?.[role]?.[permission.key])}
+                        disabled={LOCKED_PERMISSION_ROLES.has(role)}
+                        onChange={(event) => updateRolePermission(role, permission.key, event.target.checked)}
                       />
                     ))}
                   </div>

--- a/apps/web/src/pages/wizarr.jsx
+++ b/apps/web/src/pages/wizarr.jsx
@@ -226,18 +226,22 @@ export default function WizarrPage() {
           <article>
             <span>Total invites</span>
             <strong>{data?.status?.invites ?? inviteStats.all}</strong>
+            <small>All links</small>
           </article>
           <article>
             <span>Active</span>
             <strong>{inviteStats.active}</strong>
+            <small>Ready to use</small>
           </article>
           <article>
             <span>Users</span>
             <strong>{data?.status?.users ?? 0}</strong>
+            <small>Wizarr accounts</small>
           </article>
           <article>
             <span>Servers</span>
             <strong>{data?.servers?.length ?? 0}</strong>
+            <small>Destinations</small>
           </article>
         </section>
       ) : null}
@@ -419,7 +423,7 @@ export default function WizarrPage() {
                   <button type="button" onClick={() => copyInvite(invite)} disabled={!invite.url} title="Copy invite link">
                     <ClipboardLineIcon size={18} />
                   </button>
-                  <a href={invite.url} target="_blank" rel="noreferrer" title="Open invite">
+                  <a href={invite.url || "#"} target="_blank" rel="noreferrer" title="Open invite" aria-disabled={!invite.url}>
                     <ExternalLinkLineIcon size={18} />
                   </a>
                   <button type="button" className="is-danger" onClick={() => deleteInvite(invite)} title="Delete invite">

--- a/apps/web/src/routes.jsx
+++ b/apps/web/src/routes.jsx
@@ -18,13 +18,16 @@ const Integrations = lazy(() => import("./pages/integrations"));
 const Calendar = lazy(() => import("./pages/calendar"));
 const Requests = lazy(() => import("./pages/requests"));
 const Downloads = lazy(() => import("./pages/downloads"));
+const ActiveTranscodes = lazy(() => import("./pages/active-transcodes"));
+const AutomationHealth = lazy(() => import("./pages/automation-health"));
 const ServerManagement = lazy(() => import("./pages/server-management"));
 const Wizarr = lazy(() => import("./pages/wizarr"));
 
 const routes = [
   { path: "/", element: <Home />, exact: true },
+  { path: "/kiosk", element: <Home kioskMode />, exact: true },
   { path: "/home/kiosk", element: <Home kioskMode />, exact: true },
-  { path: "/settings", element: <Settings />, exact: true },
+  { path: "/settings/*", element: <Settings />, exact: true },
   { path: "/users", element: <Users />, exact: true },
   { path: "/users/:UserId", element: <UserProfilePage />, exact: true },
   { path: "/libraries", element: <Libraries />, exact: true },
@@ -35,9 +38,11 @@ const routes = [
   { path: "/calendar", element: <Calendar />, exact: true },
   { path: "/requests", element: <Requests />, exact: true },
   { path: "/downloads", element: <Downloads />, exact: true },
+  { path: "/active-transcodes", element: <ActiveTranscodes />, exact: true },
+  { path: "/automation-health", element: <AutomationHealth />, exact: true },
   { path: "/wizarr", element: <Wizarr />, exact: true },
   { path: "/server-management", element: <ServerManagement />, exact: true },
-  { path: "/repair", element: <Navigate to="/settings?tab=tabRepair" replace />, exact: true },
+  { path: "/repair", element: <Navigate to="/settings/repair" replace />, exact: true },
   { path: "/statistics", element: <Statistics />, exact: true },
   { path: "/activity", element: <Activity />, exact: true },
   { path: "/timeline", element: <ActivityTimeline />, exact: true },

--- a/apps/web/src/whats-new.json
+++ b/apps/web/src/whats-new.json
@@ -1,4 +1,46 @@
 {
+  "1.2.3.beta.1": [
+    {
+      "icon": "palette",
+      "title": "Big UI Beta",
+      "body": "Home, Settings, Statistics, Requests, Activity, Users, Wizarr, About, and integrations have all had a proper redesign pass with cleaner spacing, cards, and controls."
+    },
+    {
+      "icon": "speed",
+      "title": "Tdarr Transcodes",
+      "body": "Tdarr now has an Active Transcodes page with active, queued, and history views, navigation counts, show artwork, conversion details, and live progress updates."
+    },
+    {
+      "icon": "magic",
+      "title": "Smarter Settings",
+      "body": "Settings now uses stable grouped sections, cleaner routes, Kiosk controls, privacy options, sidebar ordering, hidden tabs, and a safer theme preview flow."
+    },
+    {
+      "icon": "movie",
+      "title": "Cleaner Requests",
+      "body": "Requests now has richer media cards, an optional list view, requester profile pictures, admin user filtering, tidier actions, and user-scoped visibility for non-admins."
+    },
+    {
+      "icon": "upload",
+      "title": "Kiosk And Privacy",
+      "body": "Kiosk mode can stay static, refresh every 5 minutes, and show only enabled sections. IP visibility can now be controlled for Home, Kiosk, both, or neither."
+    },
+    {
+      "icon": "palette",
+      "title": "Hall Of Fame Glow-Up",
+      "body": "Hall of Fame now uses a podium-style layout with medal icons, and hidden users are filtered out of Hall of Fame and Activity."
+    },
+    {
+      "icon": "speed",
+      "title": "Statistics Rebuilt",
+      "body": "Statistics has clearer summary panels, redesigned watch stats, profile pictures, client icons, and media links through to JellyGlance media pages where possible."
+    },
+    {
+      "icon": "magic",
+      "title": "Sharper Polish",
+      "body": "Profile modal sizing, account labels, sidebar collapse, profile hover pills, device icons, backup sizing, and several clipped or cramped layouts have been cleaned up."
+    }
+  ],
   "1.2.2": [
     {
       "icon": "magic",


### PR DESCRIPTION
# JellyGlance v1.2.3 Beta 1

## The Big Glow-Up

### A Redesigned JellyGlance

- Refreshed the main UI across Home, Settings, Statistics, Requests, Activity, Users, Wizarr, About, and integrations.
- Tightened page spacing, card sizing, modal sizing, and sidebar behaviour.
- Cleaned up hover states, active pills, category labels, and sidebar twitching.

### A Smarter Home

- Reworked Home into a cleaner operations-style dashboard.
- Removed the old Command Center hero copy.
- Kept Active Session cards a consistent size so multiple streams behave properly.
- Improved viewer, profile image, client, bitrate, IP, playback, and transcode details.
- Added a lighter completed-transcode segment when a stream is transcoding.
- Redesigned Hall of Fame into a podium layout with medal icons.
- Hidden users are now excluded from Hall of Fame.

### Widgets, But Tidy

- Added widget editor support for choosing what appears on Home.
- Added optional widgets for Tdarr, Wizarr, Bazarr, and Prowlarr.
- New service widgets stay hidden by default until users enable them.
- Improved library card/list sizing so metric tiles are less likely to clip or crowd.

## Tdarr Arrives

### Active Transcodes Page

- Added Tdarr integration support.
- Added a dedicated Active Transcodes page.
- Added an Active Transcodes sidebar item that only appears when Tdarr is enabled.
- Added active transcode counts in the navigation.
- Added Active, Queued, and History views on the same page.

### Better Transcode Cards

- Added show thumbnail/poster support.
- Improved transcode image quality.
- Added progress bars and active percentage updates without a manual refresh.
- Added clearer source-to-target conversion display.
- Added queued target format display using a cleaner `source > target` style.
- Added history conversion details, including before/after information and space saved where available.

## Requests Reworked

- Redesigned Requests around richer media cards.
- Added an optional list view.
- Added admin user filtering.
- Added requester profile pictures.
- Improved request card spacing, sizing, formatting, and action buttons.
- Removed old summary blocks and leftover dead space.
- Improved the 7-day trend card.
- Non-admin and non-owner users now only see their own requests.

## Settings, Finally Behaving

### New Settings Flow

- Rebuilt the Settings sidebar into stable grouped sections:
  - Core
  - Media
  - Connections
  - Operations
- Added cleaner settings routes such as `/settings/general`, `/settings/security`, and integration sub-pages.
- Improved General settings with proper form-style controls.
- Moved navigation order controls into the General page layout.
- Added sidebar ordering and hide/show controls while keeping Home, Settings, and About locked.
- Added icon-only sidebar collapse support.

### Theme And Appearance

- Improved theme preset previews.
- Theme changes now preview first
- Added a Custom theme option.
- Improved custom colour handling.
- Cleaned up profile modal sizing, alignment, text readability, and footer buttons.
- Account labels now show Jellyfin User or Jellyfin Admin where appropriate.

### Kiosk And Privacy

- Added Kiosk customisation in Settings.
- Kiosk can now behave like a static dashboard and refresh every 5 minutes.
- Active Sessions are the default Kiosk section.
- Users can choose which Kiosk sections are enabled.
- Added IP visibility controls for Home, Kiosk, both, or neither.
- Activity hides IP addresses by default.

## Activity And Users

### Users Page

- Redesigned Users into profile cards.
- Added a list view option.
- Added user hide/show controls with cleaner eye icons.
- Improved role and permission controls.
- Improved card density, spacing, and text handling.

### Activity Page

- Redesigned Activity rows around poster, title, user profile, client, device, transcode state, and date.
- Hidden users are filtered out of Activity.
- IP addresses are hidden by default.

## Statistics Rebuilt

- Redesigned Statistics with clearer summary panels.
- Reworked watch statistics so it no longer duplicates the new stat layout.
- Added profile pictures to user stat cards.
- Added device/client icons to client stat cards.
- Linked media stat items through to JellyGlance media pages where possible.
- Removed noisy mode, window, and refresh cards from the top of the page.

## Integrations Get Prettier

- Improved the Integrations page layout and cards.
- Added Home Assistant icon support.
- Improved client/device logo matching for:
  - Seerr
  - Reclaimerr
  - Jellyfin Web
  - Jellyfin Android
  - Jellyfin UWP
  - Jellystat
- Added Tdarr integration surface.
- Prepared UI space for deeper Seerr/Overseerr, Bazarr, and Prowlarr style data.
- Improved integration health and background task handling.

## About Page Polish

- Updated About with missing feature coverage.
- Added project owner and contributor sections.
- Added GitHub profile cards with profile pictures.
- Removed bot wording from contributor display.
- Reworked the contributor area so it sits in a more useful place.


## Beta Notes

- This is a beta release, so please expect a few edges.
- Tdarr data can vary depending on setup, so please test active, queued, and history states.
- Kiosk and privacy settings are worth checking after upgrading if you use public displays.
- No database reset should be required.

Enjoy the glow-up.
