### PR TITLE
fix: use semver beta release version

### DIFF
--- a/.github/RELEASE.BETA
+++ b/.github/RELEASE.BETA
@@ -1,4 +1,4 @@
-version: v1.2.3.beta.1
+version: 1.2.3-beta.1
 title: JellyGlance v1.2.3 Beta 1
 ---
 # JellyGlance v1.2.3 Beta 1

--- a/.github/RELEASE.beta
+++ b/.github/RELEASE.beta
@@ -1,4 +1,4 @@
-version: v1.2.3.beta.1
+version: 1.2.3-beta.1
 title: JellyGlance v1.2.3 Beta 1
 ---
 # JellyGlance v1.2.3 Beta 1


### PR DESCRIPTION
## Summary
- change beta release metadata from `v1.2.3.beta.1` to valid semver `1.2.3-beta.1`
- keep release title/display text as JellyGlance v1.2.3 Beta 1

## Checks
- workflow semver parser run locally
- git diff --check