### PR TITLE
fix: prevent crash-restart loop from unhandled refreshMaterializedView rejections

### DIFF
--- a/apps/api/db.js
+++ b/apps/api/db.js
@@ -53,7 +53,9 @@ async function deleteBulk(table_name, data, pkName) {
 
     if (table_name === "jf_playback_activity") {
       for (const view of materializedViews) {
-        refreshMaterializedView(view);
+        refreshMaterializedView(view).catch((error) => {
+          console.error(`Failed to refresh materialized view "${view}":`, error.message);
+        });
       }
     }
   } catch (error) {
@@ -168,7 +170,9 @@ async function insertBulk(table_name, data, columns) {
 
     if (table_name === "jf_playback_activity") {
       for (const view of materializedViews) {
-        refreshMaterializedView(view);
+        refreshMaterializedView(view).catch((error) => {
+          console.error(`Failed to refresh materialized view "${view}":`, error.message);
+        });
       }
     }
   } catch (error) {
@@ -194,7 +198,9 @@ async function query(text, params, refreshViews = false) {
 
     if (refreshViews) {
       for (const view of materializedViews) {
-        refreshMaterializedView(view);
+        refreshMaterializedView(view).catch((error) => {
+          console.error(`Failed to refresh materialized view "${view}":`, error.message);
+        });
       }
     }
 


### PR DESCRIPTION
Fixes #79.

## Problem

`refreshMaterializedView()` is called fire-and-forget from `insertBulk()`, `deleteBulk()`, and `query()` whenever `jf_playback_activity` changes (`apps/api/db.js`), but the returned promise is never `await`ed or caught anywhere in the call chain.

Under a burst of near-simultaneous playback webhook events (a handful of concurrent sessions is enough), overlapping `REFRESH MATERIALIZED VIEW` calls (no `CONCURRENTLY`, so they serialize on an exclusive lock) can exhaust the `pg` pool (`max: 20`, `connectionTimeoutMillis: 2000`) faster than locks clear. The next `pool.connect()` — including the app's own startup refresh — then times out. Since nothing catches that rejection, Node kills the whole process on the unhandled rejection, systemd restarts it, and the new process's startup refresh can hit the same still-draining lock backlog immediately, producing a **permanent crash-restart loop** from what should be a single failed background refresh.

Full root-cause writeup with logs is in #79.

## Fix

Minimal, additive-only change: attach `.catch()` at each of the 3 fire-and-forget call sites so a refresh failure is logged and the process keeps running instead of crashing. This doesn't change the underlying lock-contention behavior (a refresh can still fail under heavy overlap) — it just makes that failure non-fatal, matching how every other error path in this file already behaves (log and continue, not crash). A more thorough fix (debounce/coalesce per-view refreshes, or `REFRESH MATERIALIZED VIEW CONCURRENTLY` with a supporting unique index) would address the contention itself and could be a good follow-up, but felt out of scope for a minimal stability fix.

## Verification

Reproduced the original crash-restart loop on a live instance (native systemd install, not Docker) by registering 6 fake concurrent Jellyfin sessions — 16+ restarts, confirmed via `journalctl`. Applied this exact patch, restarted, then re-ran repeated bursts of the same 6-session load (10+ consecutive `insertBulk` batches within a 13-second window, each fanning out to 3 refresh calls — a tighter burst than the original repro). Result: **zero restarts**, continuous uptime throughout, matching the intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)